### PR TITLE
Warm library palette + chromeless shelves

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "frontend",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev"],
-      "port": 3000
+      "port": 3000,
+      "autoPort": true
     },
     {
       "name": "server",

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -22,11 +22,26 @@ This is the aesthetic contract for the personal site. `/design-loop` measures ev
 - **Sterile flatness** — pure flat Material-style minimalism with no warmth or material hint. Grounded, not sterile.
 - **Visual noise** — competing accents, decorative bloat, too many colors, busy textures behind text.
 
+## Palette — the four-note library chord
+
+The site commits to four colors, used in roughly 60/25/10/<5 proportions. Every new surface should reach for one of these registers before inventing anything.
+
+- **Paper** — cream (`#f4ecd8` / `#faf5ea` / `#ebe0c6`). The ground. Body background, card fills, popover surfaces.
+- **Ink** — navy (`#15263f` / `#172331`). Primary text, anchors, navbar frame, book-hover tooltips (navy-cloth-bound panels on cream paper).
+- **Wood** — walnut (`#4a3423` / `#6b4f35`). Secondary / meta ink: dividers, rules, chip borders, shelf graphics, inactive menu rows, warm drop-shadows under books. Replaces the cool-slate grays elsewhere in the site.
+- **Stamp** — oxblood (`#9e3a2a` / `#b54a37`). ≤10% usage: navbar active pill, house dingbat (◆), currently-reading ember glow, link-hover color, filter popover selection marker. Never the dominant color on a surface.
+
+Temperature alignment is the whole point — warm ground plus one warm neutral plus one warm accent, with navy as the cool ink that grounds everything. Cool-blue accents (the legacy `secondary`) are retired from visible surfaces; keep only for focus-rings and legacy components until they're touched.
+
 ## Pattern vocabulary
 
 Names for patterns as they emerge and get validated. New additions require earning their keep — reach for existing ones first.
 
-- _(empty — to be filled in as `/design-loop` surfaces patterns worth naming)_
+- **Paper-slip popover** — extends `site-card-soft`. Cream-paper background (`rgba(250,245,234,0.94)` over backdrop-blur), 14px radius, walnut hairline border (`rgba(74,52,35,0.18)`), warm drop-shadow with a cream inset highlight, navy body ink. Use for transient surfaces that sit atop content and should read as a slip of paper laid on the page. Selected rows get a walnut whisper tint (`rgba(74,52,35,0.08)`) and a small oxblood `◆` marker; hover rows get a walnut breath tint (`rgba(74,52,35,0.04)`).
+- **Paper-slip chip** — extends `site-link-chip` for removable selections. Cream-paper fill, 12px radius, walnut hairline border, mono caps at ~0.64rem / 0.14em tracking, trailing `×` in quiet walnut ink that warms to oxblood on hover. Reads as a small index slip inline with surrounding typography.
+- **House dingbat (◆)** — a small oxblood diamond used as the house mark across the site. Appears as: the selection marker inside the paper-slip popover; the signature eyebrow on the About page (walnut rule + ◆ + walnut rule); the ember glow beneath currently-reading books (same ink, different form). The repetition is the signature — new uses should extend this vocabulary rather than invent alternatives.
+- **Warm navbar pill** — navy-glass active pill with oxblood-tinted border and fill (`border-oxblood/50 bg-[rgba(158,58,42,0.28)]`), white text. Used for the active nav link. This is the single warm-on-dark treatment on the site and serves as the navbar's "lifted" element.
+- **Navy-cloth tooltip** — small Radix tooltip styled as a navy-glass panel (matches the navbar material) with cream/90 text and cream-tinted shelf pills inside. Reads as a navy-cloth-bound bookmark floating next to the content.
 
 ## Notes
 

--- a/frontend/src/components/books/BookCard.tsx
+++ b/frontend/src/components/books/BookCard.tsx
@@ -18,10 +18,10 @@ const BookCard: React.FC<BookCardProps> = ({ book, bookSize }) => {
 
   const tooltipContent = (
     <div className="flex flex-col gap-1 text-left">
-      <h3 className="font-serif text-sm font-semibold leading-snug text-stone-50">
+      <h3 className="font-serif text-sm font-semibold leading-snug text-cream">
         {book.title}
       </h3>
-      <p className="text-xs text-stone-300 leading-tight">{book.author}</p>
+      <p className="text-xs leading-tight text-cream/75">{book.author}</p>
       {book.rating !== null && book.rating !== undefined && (
         <div className="mt-0.5">
           <Rating value={book.rating} max={5} size="sm" />
@@ -32,7 +32,7 @@ const BookCard: React.FC<BookCardProps> = ({ book, bookSize }) => {
           {book.shelves.slice(0, 3).map((shelf: BookshelfSummary) => (
             <span
               key={shelf.id}
-              className="rounded-md bg-secondary/20 px-1.5 py-0.5 font-mono text-[0.6rem] uppercase tracking-[0.06em] text-secondary-light"
+              className="rounded-md border border-cream/20 bg-cream/10 px-1.5 py-0.5 font-mono text-[0.6rem] uppercase tracking-[0.06em] text-cream/85"
             >
               {shelf.name}
             </span>
@@ -44,23 +44,24 @@ const BookCard: React.FC<BookCardProps> = ({ book, bookSize }) => {
 
   return (
     <div
-      className="group/book flex justify-center last:border-r-0 rounded-[15px] transition-all duration-500 ease-[cubic-bezier(0.19,1,0.22,1)] shadow-[0_12px_22px_rgba(9,18,31,0.24)] hover:-translate-y-3 hover:scale-[1.06] hover:shadow-[0_24px_48px_rgba(9,18,31,0.35),0_8px_16px_rgba(9,18,31,0.2)]"
+      className="group/book flex justify-center last:border-r-0 rounded-[15px] transition-all duration-500 ease-[cubic-bezier(0.19,1,0.22,1)] shadow-[0_12px_22px_rgba(74,52,35,0.22)] hover:-translate-y-3 hover:scale-[1.06] hover:shadow-[0_24px_48px_rgba(74,52,35,0.32),0_8px_16px_rgba(74,52,35,0.18)]"
       style={{
         width: `${bookSize.width}px`,
         height: `${bookSize.height}px`,
       }}
     >
       <div className="relative h-full w-full overflow-hidden rounded-[15px]">
+        {/* Hover glow — warm amber/oxblood, like a reading lamp passing over the spine */}
         <div
           aria-hidden="true"
-          className="pointer-events-none absolute -inset-3 rounded-[22px] bg-[radial-gradient(circle_at_50%_18%,rgba(132,181,255,0.32),transparent_56%)] opacity-0 blur-xl transition duration-[900ms] ease-[cubic-bezier(0.19,1,0.22,1)] group-hover/book:opacity-100"
+          className="pointer-events-none absolute -inset-3 rounded-[22px] bg-[radial-gradient(circle_at_50%_18%,rgba(158,58,42,0.22),transparent_56%)] opacity-0 blur-xl transition duration-[900ms] ease-[cubic-bezier(0.19,1,0.22,1)] group-hover/book:opacity-100"
         />
         <Tooltip content={tooltipContent} side="right" sideOffset={12} delayDuration={150}>
           <a
             href={book.book_link || '#'}
             target="_blank"
             rel="noopener noreferrer"
-            className="group block h-full w-full rounded-[15px] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-primary-dark focus:ring-secondary/70"
+            className="group block h-full w-full rounded-[15px] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-cream focus:ring-oxblood/60"
             aria-label={`${book.title} by ${book.author}${book.rating ? `, rated ${book.rating} of 5` : ''}`}
           >
             <img
@@ -70,7 +71,7 @@ const BookCard: React.FC<BookCardProps> = ({ book, bookSize }) => {
               onError={handleImageError}
               loading="lazy"
             />
-            <div className="pointer-events-none absolute inset-0 rounded-[15px] border border-white/8 shadow-[inset_0_1px_0_rgba(255,255,255,0.16)]" />
+            <div className="pointer-events-none absolute inset-0 rounded-[15px] border border-white/8 shadow-[inset_0_1px_0_rgba(255,253,244,0.18)]" />
           </a>
         </Tooltip>
       </div>

--- a/frontend/src/components/bookshelf/BookshelfControls.tsx
+++ b/frontend/src/components/bookshelf/BookshelfControls.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Bookshelf, SortOption } from 'types/index';
+import Icon from '@/components/common/Icon';
 
 interface BookshelfControlsProps {
   sortOptions: SortOption[];
@@ -19,12 +20,11 @@ const INK_NAVY = '#15263f';
 const INK_NAVY_DIM = 'rgba(21, 38, 63, 0.55)';
 const INK_NAVY_QUIET = 'rgba(21, 38, 63, 0.35)';
 const CREAM = '#f4ecd8';
-const CREAM_DEEP = '#e4d7bc';
 const INK = '#2a1f14';
 const INK_DIM = '#6d6046';
 const INK_RULE = 'rgba(58, 42, 30, 0.18)';
 
-// Cream popover card, same language as before — floats as a typed card
+// ─── Popover ────────────────────────────────────────────────────────────────
 const Popover: React.FC<{
   open: boolean;
   onClose: () => void;
@@ -86,10 +86,73 @@ const Popover: React.FC<{
   );
 };
 
-// Filter value as a typographic anchor — navy on sky, with a subtle underline
-interface ValueProps {
+// ─── Sort anchor ("SORT · Recent") ─────────────────────────────────────────
+interface SortAnchorProps {
   label: string;
   value: string;
+  open: boolean;
+  onToggle: () => void;
+  renderPopover: (ctx: { close: () => void }) => React.ReactNode;
+}
+
+const SortAnchor: React.FC<SortAnchorProps> = ({
+  label,
+  value,
+  open,
+  onToggle,
+  renderPopover,
+}) => {
+  const ref = useRef<HTMLButtonElement>(null);
+  return (
+    <span className="relative inline-flex items-baseline gap-2">
+      <span
+        className="font-mono uppercase"
+        style={{
+          color: INK_NAVY_DIM,
+          fontSize: '0.62rem',
+          letterSpacing: '0.22em',
+          fontWeight: 500,
+        }}
+      >
+        {label}
+      </span>
+      <button
+        ref={ref}
+        type="button"
+        onClick={onToggle}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        className="inline-flex items-center font-mono uppercase transition focus:outline-none"
+        style={{
+          color: INK_NAVY,
+          fontSize: '0.7rem',
+          letterSpacing: '0.14em',
+          fontWeight: 600,
+          borderBottom: `1px solid ${open ? INK_NAVY : INK_NAVY_QUIET}`,
+          paddingBottom: 2,
+          backgroundColor: 'transparent',
+        }}
+        onMouseEnter={(e) => {
+          if (!open) e.currentTarget.style.borderBottomColor = INK_NAVY_DIM;
+        }}
+        onMouseLeave={(e) => {
+          if (!open) e.currentTarget.style.borderBottomColor = INK_NAVY_QUIET;
+        }}
+      >
+        {value}
+      </button>
+      <Popover open={open} onClose={onToggle} width={220} anchorRef={ref}>
+        {renderPopover({ close: onToggle })}
+      </Popover>
+    </span>
+  );
+};
+
+// ─── Icon button (shelf, search) ───────────────────────────────────────────
+interface IconButtonProps {
+  icon: 'shelf' | 'search';
+  ariaLabel: string;
+  active: boolean;
   open: boolean;
   onToggle: () => void;
   popoverWidth?: number;
@@ -97,50 +160,44 @@ interface ValueProps {
   renderPopover: (ctx: { close: () => void }) => React.ReactNode;
 }
 
-const Value = React.forwardRef<HTMLButtonElement, ValueProps>(
-  ({ label, value, open, onToggle, popoverWidth, popoverAlign, renderPopover }, ref) => {
+const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
+  (
+    { icon, ariaLabel, active, open, onToggle, popoverWidth, popoverAlign, renderPopover },
+    ref,
+  ) => {
     const localRef = useRef<HTMLButtonElement>(null);
     React.useImperativeHandle(ref, () => localRef.current as HTMLButtonElement);
 
+    const color = active || open ? INK_NAVY : INK_NAVY_DIM;
+
     return (
-      <span className="relative inline-flex items-baseline gap-2">
-        <span
-          className="font-mono uppercase"
-          style={{
-            color: INK_NAVY_DIM,
-            fontSize: '0.62rem',
-            letterSpacing: '0.22em',
-            fontWeight: 500,
-          }}
-        >
-          {label}
-        </span>
+      <span className="relative inline-flex items-center">
         <button
           ref={localRef}
           type="button"
           onClick={onToggle}
+          aria-label={ariaLabel}
           aria-haspopup="menu"
           aria-expanded={open}
-          className="inline-flex items-center font-mono uppercase transition focus:outline-none"
+          className="inline-flex items-center justify-center transition focus:outline-none"
           style={{
-            color: INK_NAVY,
-            fontSize: '0.7rem',
-            letterSpacing: '0.14em',
-            fontWeight: 600,
-            borderBottom: `1px solid ${open ? INK_NAVY : INK_NAVY_QUIET}`,
-            paddingBottom: 2,
-            paddingLeft: 0,
-            paddingRight: 0,
+            color,
+            width: 22,
+            height: 22,
+            padding: 0,
             backgroundColor: 'transparent',
+            borderBottom: `1px solid ${open ? INK_NAVY : 'transparent'}`,
+            paddingBottom: 2,
+            marginBottom: -3,
           }}
           onMouseEnter={(e) => {
-            if (!open) e.currentTarget.style.borderBottomColor = INK_NAVY_DIM;
+            if (!open && !active) e.currentTarget.style.color = INK_NAVY;
           }}
           onMouseLeave={(e) => {
-            if (!open) e.currentTarget.style.borderBottomColor = INK_NAVY_QUIET;
+            if (!open && !active) e.currentTarget.style.color = INK_NAVY_DIM;
           }}
         >
-          {value}
+          <Icon name={icon} size="sm" />
         </button>
         <Popover
           open={open}
@@ -155,8 +212,46 @@ const Value = React.forwardRef<HTMLButtonElement, ValueProps>(
     );
   },
 );
-Value.displayName = 'Value';
+IconButton.displayName = 'IconButton';
 
+// ─── Active-filter chip ─────────────────────────────────────────────────────
+const FilterChip: React.FC<{ label: string; onRemove: () => void; title?: string }> = ({
+  label,
+  onRemove,
+  title,
+}) => (
+  <button
+    type="button"
+    onClick={onRemove}
+    className="inline-flex items-center gap-1.5 font-mono uppercase transition"
+    style={{
+      color: INK_NAVY,
+      fontSize: '0.6rem',
+      letterSpacing: '0.16em',
+      backgroundColor: 'transparent',
+      padding: '2px 8px',
+      border: `1px solid ${INK_NAVY_QUIET}`,
+      borderRadius: 2,
+      whiteSpace: 'nowrap',
+    }}
+    onMouseEnter={(e) => {
+      e.currentTarget.style.backgroundColor = 'rgba(21, 38, 63, 0.05)';
+      e.currentTarget.style.borderColor = INK_NAVY_DIM;
+    }}
+    onMouseLeave={(e) => {
+      e.currentTarget.style.backgroundColor = 'transparent';
+      e.currentTarget.style.borderColor = INK_NAVY_QUIET;
+    }}
+    title={title}
+  >
+    {label}
+    <span aria-hidden="true" style={{ color: INK_NAVY_DIM, fontSize: '0.72rem', lineHeight: 1 }}>
+      ×
+    </span>
+  </button>
+);
+
+// ─── Main component ─────────────────────────────────────────────────────────
 const BookshelfControls: React.FC<BookshelfControlsProps> = ({
   sortOptions,
   selectedSortBy,
@@ -187,27 +282,21 @@ const BookshelfControls: React.FC<BookshelfControlsProps> = ({
   const sortLabel =
     sortOptions.find((o) => o.value === selectedSortBy)?.label.toUpperCase() ?? '—';
 
-  const shelvesLabel =
-    selectedShelfIds.length === 0
-      ? 'ALL'
-      : selectedShelfIds.length === 1
-      ? (allBookshelves.find((s) => s.id === selectedShelfIds[0])?.name ?? '1').toUpperCase()
-      : `${selectedShelfIds.length} SELECTED`;
-
-  const searchLabel = searchQuery.trim() ? `"${searchQuery.trim().toUpperCase()}"` : 'ALL';
-
   const handleToggle = (which: 'sort' | 'shelves' | 'search') =>
     setOpenSegment((cur) => (cur === which ? null : which));
 
+  const searchActive = searchQuery.trim().length > 0;
+  const selectedShelves = allBookshelves.filter((s) => selectedShelfIds.includes(s.id));
+
   return (
-    <div className="relative flex flex-wrap items-baseline justify-between gap-x-8 gap-y-3">
-      <div className="flex flex-wrap items-baseline gap-x-6 gap-y-3">
-        <Value
+    <div className="relative flex flex-wrap items-center justify-between gap-x-6 gap-y-2">
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+        {/* SORT · Recent */}
+        <SortAnchor
           label="Sort"
           value={sortLabel}
           open={openSegment === 'sort'}
           onToggle={() => handleToggle('sort')}
-          popoverWidth={220}
           renderPopover={({ close }) => (
             <ul className="py-1.5" role="menu">
               {sortOptions.map((opt) => {
@@ -250,9 +339,15 @@ const BookshelfControls: React.FC<BookshelfControlsProps> = ({
           )}
         />
 
-        <Value
-          label="Shelf"
-          value={shelvesLabel}
+        {/* Shelf icon button */}
+        <IconButton
+          icon="shelf"
+          ariaLabel={
+            selectedShelves.length > 0
+              ? `Filter by shelf (${selectedShelves.length} selected)`
+              : 'Filter by shelf'
+          }
+          active={selectedShelves.length > 0}
           open={openSegment === 'shelves'}
           onToggle={() => handleToggle('shelves')}
           popoverWidth={260}
@@ -318,9 +413,11 @@ const BookshelfControls: React.FC<BookshelfControlsProps> = ({
           )}
         />
 
-        <Value
-          label="Search"
-          value={searchLabel}
+        {/* Search icon button */}
+        <IconButton
+          icon="search"
+          ariaLabel={searchActive ? `Search: ${searchQuery}` : 'Search books'}
+          active={searchActive}
           open={openSegment === 'search'}
           onToggle={() => handleToggle('search')}
           popoverWidth={300}
@@ -375,6 +472,23 @@ const BookshelfControls: React.FC<BookshelfControlsProps> = ({
             </div>
           )}
         />
+
+        {/* Inline active-filter chips — sit on the same horizontal plane */}
+        {searchActive && (
+          <FilterChip
+            label={`"${searchQuery.trim()}"`}
+            onRemove={() => onSearchChange('')}
+            title="Clear search"
+          />
+        )}
+        {selectedShelves.map((shelf) => (
+          <FilterChip
+            key={shelf.id}
+            label={shelf.name}
+            onRemove={() => onToggleShelf(shelf.id)}
+            title="Remove shelf filter"
+          />
+        ))}
       </div>
 
       {/* Volume count — trailing colophon */}
@@ -395,74 +509,3 @@ const BookshelfControls: React.FC<BookshelfControlsProps> = ({
 };
 
 export default BookshelfControls;
-
-// Sidecar: active-shelves chip rail
-export const BookshelfSelectionChips: React.FC<{
-  allBookshelves: Bookshelf[];
-  selectedShelfIds: number[];
-  onToggleShelf: (id: number) => void;
-  onClearShelves: () => void;
-}> = ({ allBookshelves, selectedShelfIds, onToggleShelf, onClearShelves }) => {
-  if (selectedShelfIds.length === 0) return null;
-  const selected = allBookshelves.filter((s) => selectedShelfIds.includes(s.id));
-
-  return (
-    <div className="flex flex-wrap items-center gap-2">
-      <span
-        className="font-mono uppercase"
-        style={{
-          color: INK_NAVY_DIM,
-          fontSize: '0.56rem',
-          letterSpacing: '0.22em',
-        }}
-      >
-        On shelf
-      </span>
-      {selected.map((shelf) => (
-        <button
-          key={shelf.id}
-          type="button"
-          onClick={() => onToggleShelf(shelf.id)}
-          className="inline-flex items-center gap-1.5 font-mono uppercase transition"
-          style={{
-            color: INK_NAVY,
-            fontSize: '0.6rem',
-            letterSpacing: '0.16em',
-            backgroundColor: 'transparent',
-            padding: '2px 8px',
-            border: `1px solid ${INK_NAVY_QUIET}`,
-            borderRadius: 2,
-          }}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.backgroundColor = 'rgba(21, 38, 63, 0.05)';
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.backgroundColor = 'transparent';
-          }}
-          title="Remove shelf filter"
-        >
-          {shelf.name}
-          <span aria-hidden="true" style={{ color: INK_NAVY_DIM, fontSize: '0.7rem' }}>
-            ×
-          </span>
-        </button>
-      ))}
-      {selected.length > 1 && (
-        <button
-          type="button"
-          onClick={onClearShelves}
-          className="font-mono uppercase"
-          style={{
-            color: INK_NAVY_DIM,
-            fontSize: '0.56rem',
-            letterSpacing: '0.22em',
-          }}
-        >
-          Clear all
-        </button>
-      )}
-      {/* touch exports so lint doesn't flag */}
-      <span style={{ display: 'none' }}>{CREAM_DEEP}</span>
-    </div>
-  );
-};

--- a/frontend/src/components/bookshelf/BookshelfControls.tsx
+++ b/frontend/src/components/bookshelf/BookshelfControls.tsx
@@ -86,40 +86,42 @@ const Popover: React.FC<{
   );
 };
 
-// ─── Sort anchor ("SORT · Recent") ─────────────────────────────────────────
+// ─── Sort anchor ("[sort-icon] Recent") ────────────────────────────────────
 interface SortAnchorProps {
-  label: string;
   value: string;
+  ariaLabel: string;
   open: boolean;
   onToggle: () => void;
   renderPopover: (ctx: { close: () => void }) => React.ReactNode;
 }
 
 const SortAnchor: React.FC<SortAnchorProps> = ({
-  label,
   value,
+  ariaLabel,
   open,
   onToggle,
   renderPopover,
 }) => {
   const ref = useRef<HTMLButtonElement>(null);
   return (
-    <span className="relative inline-flex items-baseline gap-2">
+    <span className="relative inline-flex items-center gap-2">
       <span
-        className="font-mono uppercase"
+        aria-hidden="true"
         style={{
           color: INK_NAVY_DIM,
-          fontSize: '0.62rem',
-          letterSpacing: '0.22em',
-          fontWeight: 500,
+          display: 'inline-flex',
+          alignItems: 'center',
+          width: 18,
+          height: 18,
         }}
       >
-        {label}
+        <Icon name="sort" size="md" />
       </span>
       <button
         ref={ref}
         type="button"
         onClick={onToggle}
+        aria-label={ariaLabel}
         aria-haspopup="menu"
         aria-expanded={open}
         className="inline-flex items-center font-mono uppercase transition focus:outline-none"
@@ -182,8 +184,8 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
           className="inline-flex items-center justify-center transition focus:outline-none"
           style={{
             color,
-            width: 22,
-            height: 22,
+            width: 24,
+            height: 24,
             padding: 0,
             backgroundColor: 'transparent',
             borderBottom: `1px solid ${open ? INK_NAVY : 'transparent'}`,
@@ -197,7 +199,7 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
             if (!open && !active) e.currentTarget.style.color = INK_NAVY_DIM;
           }}
         >
-          <Icon name={icon} size="sm" />
+          <Icon name={icon} size="md" />
         </button>
         <Popover
           open={open}
@@ -291,10 +293,10 @@ const BookshelfControls: React.FC<BookshelfControlsProps> = ({
   return (
     <div className="relative flex flex-wrap items-center justify-between gap-x-6 gap-y-2">
       <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
-        {/* SORT · Recent */}
+        {/* [sort-icon] · Recent */}
         <SortAnchor
-          label="Sort"
           value={sortLabel}
+          ariaLabel={`Sort by ${sortLabel.toLowerCase()}`}
           open={openSegment === 'sort'}
           onToggle={() => handleToggle('sort')}
           renderPopover={({ close }) => (

--- a/frontend/src/components/bookshelf/BookshelfControls.tsx
+++ b/frontend/src/components/bookshelf/BookshelfControls.tsx
@@ -1,9 +1,5 @@
-import React from 'react';
-import { MultiSelectDropdown, SortDropdown, Tooltip } from '../ui';
+import React, { useEffect, useRef, useState } from 'react';
 import { Bookshelf, SortOption } from 'types/index';
-import SearchInput from '@/components/common/SearchInput';
-import Icon from '@/components/common/Icon';
-import BookshelfPill from '@/components/ui/BookshelfPill';
 
 interface BookshelfControlsProps {
   sortOptions: SortOption[];
@@ -18,6 +14,149 @@ interface BookshelfControlsProps {
   onSearchChange: (val: string) => void;
 }
 
+// Navy / ink / cream on pale sky — chromeless register
+const INK_NAVY = '#15263f';
+const INK_NAVY_DIM = 'rgba(21, 38, 63, 0.55)';
+const INK_NAVY_QUIET = 'rgba(21, 38, 63, 0.35)';
+const CREAM = '#f4ecd8';
+const CREAM_DEEP = '#e4d7bc';
+const INK = '#2a1f14';
+const INK_DIM = '#6d6046';
+const INK_RULE = 'rgba(58, 42, 30, 0.18)';
+
+// Cream popover card, same language as before — floats as a typed card
+const Popover: React.FC<{
+  open: boolean;
+  onClose: () => void;
+  width?: number;
+  children: React.ReactNode;
+  anchorRef: React.RefObject<HTMLElement>;
+  align?: 'left' | 'center' | 'right';
+}> = ({ open, onClose, width = 240, children, anchorRef, align = 'left' }) => {
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (e: MouseEvent) => {
+      const panel = panelRef.current;
+      const anchor = anchorRef.current;
+      if (!panel || !anchor) return;
+      const target = e.target as Node;
+      if (!panel.contains(target) && !anchor.contains(target)) {
+        onClose();
+      }
+    };
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [open, onClose, anchorRef]);
+
+  if (!open) return null;
+
+  const alignStyle =
+    align === 'center'
+      ? { left: '50%', transform: 'translateX(-50%)' }
+      : align === 'right'
+      ? { right: 0 }
+      : { left: 0 };
+
+  return (
+    <div
+      ref={panelRef}
+      className="absolute z-40"
+      style={{
+        top: 'calc(100% + 10px)',
+        width,
+        backgroundColor: CREAM,
+        color: INK,
+        border: `1px solid ${INK_RULE}`,
+        borderRadius: 3,
+        boxShadow: '0 16px 30px -16px rgba(8, 15, 28, 0.35)',
+        ...alignStyle,
+      }}
+    >
+      {children}
+    </div>
+  );
+};
+
+// Filter value as a typographic anchor — navy on sky, with a subtle underline
+interface ValueProps {
+  label: string;
+  value: string;
+  open: boolean;
+  onToggle: () => void;
+  popoverWidth?: number;
+  popoverAlign?: 'left' | 'center' | 'right';
+  renderPopover: (ctx: { close: () => void }) => React.ReactNode;
+}
+
+const Value = React.forwardRef<HTMLButtonElement, ValueProps>(
+  ({ label, value, open, onToggle, popoverWidth, popoverAlign, renderPopover }, ref) => {
+    const localRef = useRef<HTMLButtonElement>(null);
+    React.useImperativeHandle(ref, () => localRef.current as HTMLButtonElement);
+
+    return (
+      <span className="relative inline-flex items-baseline gap-2">
+        <span
+          className="font-mono uppercase"
+          style={{
+            color: INK_NAVY_DIM,
+            fontSize: '0.62rem',
+            letterSpacing: '0.22em',
+            fontWeight: 500,
+          }}
+        >
+          {label}
+        </span>
+        <button
+          ref={localRef}
+          type="button"
+          onClick={onToggle}
+          aria-haspopup="menu"
+          aria-expanded={open}
+          className="inline-flex items-center font-mono uppercase transition focus:outline-none"
+          style={{
+            color: INK_NAVY,
+            fontSize: '0.7rem',
+            letterSpacing: '0.14em',
+            fontWeight: 600,
+            borderBottom: `1px solid ${open ? INK_NAVY : INK_NAVY_QUIET}`,
+            paddingBottom: 2,
+            paddingLeft: 0,
+            paddingRight: 0,
+            backgroundColor: 'transparent',
+          }}
+          onMouseEnter={(e) => {
+            if (!open) e.currentTarget.style.borderBottomColor = INK_NAVY_DIM;
+          }}
+          onMouseLeave={(e) => {
+            if (!open) e.currentTarget.style.borderBottomColor = INK_NAVY_QUIET;
+          }}
+        >
+          {value}
+        </button>
+        <Popover
+          open={open}
+          onClose={onToggle}
+          width={popoverWidth}
+          anchorRef={localRef}
+          align={popoverAlign}
+        >
+          {renderPopover({ close: onToggle })}
+        </Popover>
+      </span>
+    );
+  },
+);
+Value.displayName = 'Value';
+
 const BookshelfControls: React.FC<BookshelfControlsProps> = ({
   sortOptions,
   selectedSortBy,
@@ -30,92 +169,300 @@ const BookshelfControls: React.FC<BookshelfControlsProps> = ({
   searchQuery,
   onSearchChange,
 }) => {
-  const goodreadsTooltipContent = (
-    <p className="p-1 text-xs italic leading-tight text-stone-100">
-      This page is sync&apos;d with my{' '}
-      <a
-        href="https://www.goodreads.com/review/list/76731654?shelf=%23ALL%23"
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-secondary-light hover:text-white"
-      >
-        Goodreads
-      </a>{' '}
-      account, where I began tracking books in 2017.
-    </p>
-  );
+  const [openSegment, setOpenSegment] = useState<null | 'sort' | 'shelves' | 'search'>(null);
+  const [searchDraft, setSearchDraft] = useState(searchQuery);
+
+  useEffect(() => {
+    setSearchDraft(searchQuery);
+  }, [searchQuery]);
+
+  useEffect(() => {
+    const t = window.setTimeout(() => {
+      if (searchDraft !== searchQuery) onSearchChange(searchDraft);
+    }, 250);
+    return () => window.clearTimeout(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchDraft]);
+
+  const sortLabel =
+    sortOptions.find((o) => o.value === selectedSortBy)?.label.toUpperCase() ?? '—';
+
+  const shelvesLabel =
+    selectedShelfIds.length === 0
+      ? 'ALL'
+      : selectedShelfIds.length === 1
+      ? (allBookshelves.find((s) => s.id === selectedShelfIds[0])?.name ?? '1').toUpperCase()
+      : `${selectedShelfIds.length} SELECTED`;
+
+  const searchLabel = searchQuery.trim() ? `"${searchQuery.trim().toUpperCase()}"` : 'ALL';
+
+  const handleToggle = (which: 'sort' | 'shelves' | 'search') =>
+    setOpenSegment((cur) => (cur === which ? null : which));
 
   return (
-    <div className="site-card-soft relative z-20 mb-5 px-4 py-4 sm:px-5 sm:py-4.5">
-      <div className="flex flex-wrap items-center gap-3 sm:gap-4">
-        <div className="flex items-center gap-2">
-          <span className="site-meta text-[0.68rem]">Sort</span>
-          <SortDropdown
-            options={sortOptions}
-            selected={selectedSortBy}
-            onChange={onSortChange}
-            className="w-40"
-          />
-        </div>
+    <div className="relative flex flex-wrap items-baseline justify-between gap-x-8 gap-y-3">
+      <div className="flex flex-wrap items-baseline gap-x-6 gap-y-3">
+        <Value
+          label="Sort"
+          value={sortLabel}
+          open={openSegment === 'sort'}
+          onToggle={() => handleToggle('sort')}
+          popoverWidth={220}
+          renderPopover={({ close }) => (
+            <ul className="py-1.5" role="menu">
+              {sortOptions.map((opt) => {
+                const active = opt.value === selectedSortBy;
+                return (
+                  <li key={opt.value}>
+                    <button
+                      type="button"
+                      role="menuitemradio"
+                      aria-checked={active}
+                      onClick={() => {
+                        onSortChange(opt.value);
+                        close();
+                      }}
+                      className="flex w-full items-center gap-2 px-3 py-1.5 font-mono text-[0.72rem] uppercase tracking-[0.14em] transition"
+                      style={{
+                        color: active ? INK : INK_DIM,
+                        backgroundColor: active ? 'rgba(58, 42, 30, 0.08)' : 'transparent',
+                      }}
+                      onMouseEnter={(e) => {
+                        if (!active)
+                          e.currentTarget.style.backgroundColor = 'rgba(58, 42, 30, 0.04)';
+                      }}
+                      onMouseLeave={(e) => {
+                        if (!active) e.currentTarget.style.backgroundColor = 'transparent';
+                      }}
+                    >
+                      <span
+                        aria-hidden="true"
+                        style={{ width: '0.7rem', color: INK, opacity: active ? 1 : 0 }}
+                      >
+                        ◆
+                      </span>
+                      {opt.label}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        />
 
-        <div className="flex items-center gap-2">
-          <span className="site-meta text-[0.68rem]">Shelves</span>
-          <MultiSelectDropdown
-            label="Select Shelves"
-            items={allBookshelves.map((shelf) => ({ id: shelf.id, label: shelf.name }))}
-            selectedItems={selectedShelfIds}
-            toggleItem={onToggleShelf}
-            className="w-44"
-          />
-        </div>
+        <Value
+          label="Shelf"
+          value={shelvesLabel}
+          open={openSegment === 'shelves'}
+          onToggle={() => handleToggle('shelves')}
+          popoverWidth={260}
+          renderPopover={() => (
+            <div>
+              <div
+                className="flex items-center justify-between px-3 pt-2 pb-1 font-mono text-[0.6rem] uppercase tracking-[0.18em]"
+                style={{ color: INK_DIM }}
+              >
+                <span>Select shelves</span>
+                {selectedShelfIds.length > 0 && (
+                  <button
+                    type="button"
+                    onClick={onClearShelves}
+                    className="transition"
+                    style={{ color: INK_DIM }}
+                    onMouseEnter={(e) => (e.currentTarget.style.color = INK)}
+                    onMouseLeave={(e) => (e.currentTarget.style.color = INK_DIM)}
+                  >
+                    Clear
+                  </button>
+                )}
+              </div>
+              <ul
+                className="max-h-64 overflow-y-auto py-1"
+                role="menu"
+                style={{ borderTop: `1px solid ${INK_RULE}` }}
+              >
+                {allBookshelves.map((shelf) => {
+                  const selected = selectedShelfIds.includes(shelf.id);
+                  return (
+                    <li key={shelf.id}>
+                      <button
+                        type="button"
+                        role="menuitemcheckbox"
+                        aria-checked={selected}
+                        onClick={() => onToggleShelf(shelf.id)}
+                        className="flex w-full items-center gap-2 px-3 py-1.5 font-mono text-[0.72rem] uppercase tracking-[0.14em] transition"
+                        style={{
+                          color: selected ? INK : INK_DIM,
+                          backgroundColor: selected
+                            ? 'rgba(58, 42, 30, 0.08)'
+                            : 'transparent',
+                        }}
+                        onMouseEnter={(e) => {
+                          if (!selected)
+                            e.currentTarget.style.backgroundColor = 'rgba(58, 42, 30, 0.04)';
+                        }}
+                        onMouseLeave={(e) => {
+                          if (!selected) e.currentTarget.style.backgroundColor = 'transparent';
+                        }}
+                      >
+                        <span aria-hidden="true" style={{ width: '0.7rem', color: INK }}>
+                          {selected ? '◆' : ''}
+                        </span>
+                        {shelf.name}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
+        />
 
-        <div className="min-w-[15rem] flex-1">
-          <SearchInput
-            value={searchQuery}
-            onChange={onSearchChange}
-            placeholder="Search books..."
-            debounceMs={300}
-            className="w-full"
-          />
-        </div>
-
-        <div className="ml-auto flex items-center gap-1.5">
-          <span className="site-meta whitespace-nowrap text-[0.68rem] normal-case tracking-[0.12em]">
-            Showing {bookCount} books
-          </span>
-          <Tooltip content={goodreadsTooltipContent} side="bottom" sideOffset={5}>
-            <span className="text-textTertiary transition hover:text-primary">
-              <Icon name="info-circle" size="sm" />
-            </span>
-          </Tooltip>
-        </div>
+        <Value
+          label="Search"
+          value={searchLabel}
+          open={openSegment === 'search'}
+          onToggle={() => handleToggle('search')}
+          popoverWidth={300}
+          renderPopover={({ close }) => (
+            <div className="px-3 py-2">
+              <label
+                className="mb-1 block font-mono text-[0.6rem] uppercase tracking-[0.18em]"
+                style={{ color: INK_DIM }}
+              >
+                Title or author
+              </label>
+              <input
+                autoFocus
+                type="text"
+                value={searchDraft}
+                onChange={(e) => setSearchDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    onSearchChange(searchDraft);
+                    close();
+                  }
+                }}
+                placeholder="e.g. Camus"
+                className="w-full bg-transparent font-mono text-[0.82rem] outline-none"
+                style={{
+                  color: INK,
+                  borderBottom: `1px solid ${INK_RULE}`,
+                  paddingBottom: 4,
+                }}
+              />
+              <div className="mt-2 flex items-center justify-between">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setSearchDraft('');
+                    onSearchChange('');
+                  }}
+                  className="font-mono text-[0.6rem] uppercase tracking-[0.18em]"
+                  style={{ color: INK_DIM }}
+                >
+                  Clear
+                </button>
+                <button
+                  type="button"
+                  onClick={close}
+                  className="font-mono text-[0.6rem] uppercase tracking-[0.18em]"
+                  style={{ color: INK }}
+                >
+                  Done
+                </button>
+              </div>
+            </div>
+          )}
+        />
       </div>
 
-      <div className={selectedShelfIds.length > 0 ? 'mt-3 min-h-8' : 'mt-2 min-h-4'}>
-        {selectedShelfIds.length > 0 && (
-          <div className="flex flex-wrap gap-1.5">
-            {allBookshelves
-              .filter((shelf) => selectedShelfIds.includes(shelf.id))
-              .map((shelf) => (
-                <BookshelfPill
-                  key={shelf.id}
-                  label={shelf.name}
-                  onRemove={() => onToggleShelf(shelf.id)}
-                />
-              ))}
-            {selectedShelfIds.length > 1 && (
-              <button
-                onClick={onClearShelves}
-                className="self-center ml-1 font-mono text-[0.66rem] uppercase tracking-[0.1em] text-textTertiary transition hover:text-primary"
-              >
-                Clear all
-              </button>
-            )}
-          </div>
-        )}
+      {/* Volume count — trailing colophon */}
+      <div
+        className="hidden font-mono uppercase sm:block"
+        style={{
+          color: INK_NAVY_DIM,
+          fontSize: '0.58rem',
+          letterSpacing: '0.24em',
+          whiteSpace: 'nowrap',
+          fontWeight: 500,
+        }}
+      >
+        {bookCount} {bookCount === 1 ? 'vol' : 'vols'}
       </div>
     </div>
   );
 };
 
-export default BookshelfControls; 
+export default BookshelfControls;
+
+// Sidecar: active-shelves chip rail
+export const BookshelfSelectionChips: React.FC<{
+  allBookshelves: Bookshelf[];
+  selectedShelfIds: number[];
+  onToggleShelf: (id: number) => void;
+  onClearShelves: () => void;
+}> = ({ allBookshelves, selectedShelfIds, onToggleShelf, onClearShelves }) => {
+  if (selectedShelfIds.length === 0) return null;
+  const selected = allBookshelves.filter((s) => selectedShelfIds.includes(s.id));
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span
+        className="font-mono uppercase"
+        style={{
+          color: INK_NAVY_DIM,
+          fontSize: '0.56rem',
+          letterSpacing: '0.22em',
+        }}
+      >
+        On shelf
+      </span>
+      {selected.map((shelf) => (
+        <button
+          key={shelf.id}
+          type="button"
+          onClick={() => onToggleShelf(shelf.id)}
+          className="inline-flex items-center gap-1.5 font-mono uppercase transition"
+          style={{
+            color: INK_NAVY,
+            fontSize: '0.6rem',
+            letterSpacing: '0.16em',
+            backgroundColor: 'transparent',
+            padding: '2px 8px',
+            border: `1px solid ${INK_NAVY_QUIET}`,
+            borderRadius: 2,
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.backgroundColor = 'rgba(21, 38, 63, 0.05)';
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.backgroundColor = 'transparent';
+          }}
+          title="Remove shelf filter"
+        >
+          {shelf.name}
+          <span aria-hidden="true" style={{ color: INK_NAVY_DIM, fontSize: '0.7rem' }}>
+            ×
+          </span>
+        </button>
+      ))}
+      {selected.length > 1 && (
+        <button
+          type="button"
+          onClick={onClearShelves}
+          className="font-mono uppercase"
+          style={{
+            color: INK_NAVY_DIM,
+            fontSize: '0.56rem',
+            letterSpacing: '0.22em',
+          }}
+        >
+          Clear all
+        </button>
+      )}
+      {/* touch exports so lint doesn't flag */}
+      <span style={{ display: 'none' }}>{CREAM_DEEP}</span>
+    </div>
+  );
+};

--- a/frontend/src/components/bookshelf/BookshelfControls.tsx
+++ b/frontend/src/components/bookshelf/BookshelfControls.tsx
@@ -15,14 +15,21 @@ interface BookshelfControlsProps {
   onSearchChange: (val: string) => void;
 }
 
-// Navy / ink / cream on pale sky — chromeless register
-const INK_NAVY = '#15263f';
-const INK_NAVY_DIM = 'rgba(21, 38, 63, 0.55)';
-const INK_NAVY_QUIET = 'rgba(21, 38, 63, 0.35)';
-const CREAM = '#f4ecd8';
-const INK = '#2a1f14';
-const INK_DIM = '#6d6046';
-const INK_RULE = 'rgba(58, 42, 30, 0.18)';
+// Palette — the four-note library chord: paper / ink / wood / stamp.
+// Paper is cream, ink is navy, wood is walnut, stamp is oxblood (used sparingly).
+// The whole filter row is a typographic slip pinned to the page in these four tones.
+const INK_NAVY = '#15263f';            // primary ink — anchors, body text
+const INK_NAVY_SOFT = '#172331';
+const WALNUT_MID = '#6b4f35';                     // body of walnut tones — inactive menu rows
+const WALNUT_MUTED = 'rgba(74, 52, 35, 0.55)';    // muted walnut — × glyphs, meta text
+const WALNUT_HAIRLINE = 'rgba(74, 52, 35, 0.18)'; // chip / popover borders, anchor underlines
+const WALNUT_WHISPER = 'rgba(74, 52, 35, 0.08)';  // active-row tint
+const WALNUT_BREATH = 'rgba(74, 52, 35, 0.04)';   // hover-row tint
+const OXBLOOD = '#9e3a2a';                        // stamp accent — selection markers, hover bump
+const OXBLOOD_SOFT = 'rgba(158, 58, 42, 0.45)';
+const CREAM_PAPER = 'rgba(250, 245, 234, 0.94)';  // slip of paper over the page
+const CREAM_CHIP = 'rgba(250, 245, 234, 0.7)';    // chip fill — warmer paper
+const CREAM_CHIP_HOT = 'rgba(250, 245, 234, 0.95)';
 
 // ─── Popover ────────────────────────────────────────────────────────────────
 const Popover: React.FC<{
@@ -69,15 +76,18 @@ const Popover: React.FC<{
   return (
     <div
       ref={panelRef}
-      className="absolute z-40"
+      className="absolute z-40 backdrop-blur-[6px]"
       style={{
         top: 'calc(100% + 10px)',
         width,
-        backgroundColor: CREAM,
-        color: INK,
-        border: `1px solid ${INK_RULE}`,
-        borderRadius: 3,
-        boxShadow: '0 16px 30px -16px rgba(8, 15, 28, 0.35)',
+        backgroundColor: CREAM_PAPER,
+        color: INK_NAVY_SOFT,
+        border: `1px solid ${WALNUT_HAIRLINE}`,
+        borderRadius: 14,
+        // Warm shadow (walnut-ink, not navy-ink) + inset cream highlight.
+        // Reads as a slip of paper laid on the page.
+        boxShadow:
+          'inset 0 1px 0 rgba(255, 253, 244, 0.9), 0 18px 36px -18px rgba(74, 52, 35, 0.28), 0 2px 6px -2px rgba(74, 52, 35, 0.12)',
         ...alignStyle,
       }}
     >
@@ -120,15 +130,15 @@ const TextAnchor: React.FC<TextAnchorProps> = ({
           fontSize: '0.7rem',
           letterSpacing: '0.14em',
           fontWeight: 600,
-          borderBottom: `1px solid ${open ? INK_NAVY : INK_NAVY_QUIET}`,
+          borderBottom: `1px solid ${open ? INK_NAVY : WALNUT_HAIRLINE}`,
           paddingBottom: 2,
           backgroundColor: 'transparent',
         }}
         onMouseEnter={(e) => {
-          if (!open) e.currentTarget.style.borderBottomColor = INK_NAVY_DIM;
+          if (!open) e.currentTarget.style.borderBottomColor = WALNUT_MUTED;
         }}
         onMouseLeave={(e) => {
-          if (!open) e.currentTarget.style.borderBottomColor = INK_NAVY_QUIET;
+          if (!open) e.currentTarget.style.borderBottomColor = WALNUT_HAIRLINE;
         }}
       >
         {value}
@@ -179,7 +189,7 @@ const InlineSearch: React.FC<InlineSearchProps> = ({
         aria-label={searchActive ? `Search: ${searchQuery}` : 'Search books'}
         className="inline-flex items-center justify-center transition focus:outline-none"
         style={{
-          color: showInput ? INK_NAVY : INK_NAVY_DIM,
+          color: showInput ? INK_NAVY : WALNUT_MUTED,
           width: 24,
           height: 24,
           padding: 0,
@@ -189,7 +199,7 @@ const InlineSearch: React.FC<InlineSearchProps> = ({
           if (!showInput) e.currentTarget.style.color = INK_NAVY;
         }}
         onMouseLeave={(e) => {
-          if (!showInput) e.currentTarget.style.color = INK_NAVY_DIM;
+          if (!showInput) e.currentTarget.style.color = WALNUT_MUTED;
         }}
       >
         <Icon name="search" size="md" />
@@ -216,7 +226,7 @@ const InlineSearch: React.FC<InlineSearchProps> = ({
               letterSpacing: '0.12em',
               fontWeight: 600,
               width: 160,
-              borderBottom: `1px solid ${INK_NAVY_QUIET}`,
+              borderBottom: `1px solid ${WALNUT_HAIRLINE}`,
               paddingBottom: 2,
             }}
           />
@@ -227,7 +237,7 @@ const InlineSearch: React.FC<InlineSearchProps> = ({
               aria-label="Clear search"
               className="transition"
               style={{
-                color: INK_NAVY_DIM,
+                color: WALNUT_MUTED,
                 fontSize: '0.9rem',
                 lineHeight: 1,
                 background: 'transparent',
@@ -235,7 +245,7 @@ const InlineSearch: React.FC<InlineSearchProps> = ({
                 marginLeft: -4,
               }}
               onMouseEnter={(e) => (e.currentTarget.style.color = INK_NAVY)}
-              onMouseLeave={(e) => (e.currentTarget.style.color = INK_NAVY_DIM)}
+              onMouseLeave={(e) => (e.currentTarget.style.color = WALNUT_MUTED)}
             >
               ×
             </button>
@@ -247,41 +257,59 @@ const InlineSearch: React.FC<InlineSearchProps> = ({
 };
 
 // ─── Active-filter chip (for selected shelves) ─────────────────────────────
+// A slip of cream paper with a walnut hairline, navy ink, and a walnut ×.
+// On hover the border warms to oxblood and the × follows — a quiet stamp
+// that says "this is removable" without shouting.
 const FilterChip: React.FC<{ label: string; onRemove: () => void; title?: string }> = ({
   label,
   onRemove,
   title,
-}) => (
-  <button
-    type="button"
-    onClick={onRemove}
-    className="inline-flex items-center gap-1.5 font-mono uppercase transition"
-    style={{
-      color: INK_NAVY,
-      fontSize: '0.6rem',
-      letterSpacing: '0.16em',
-      backgroundColor: 'transparent',
-      padding: '2px 8px',
-      border: `1px solid ${INK_NAVY_QUIET}`,
-      borderRadius: 2,
-      whiteSpace: 'nowrap',
-    }}
-    onMouseEnter={(e) => {
-      e.currentTarget.style.backgroundColor = 'rgba(21, 38, 63, 0.05)';
-      e.currentTarget.style.borderColor = INK_NAVY_DIM;
-    }}
-    onMouseLeave={(e) => {
-      e.currentTarget.style.backgroundColor = 'transparent';
-      e.currentTarget.style.borderColor = INK_NAVY_QUIET;
-    }}
-    title={title}
-  >
-    {label}
-    <span aria-hidden="true" style={{ color: INK_NAVY_DIM, fontSize: '0.72rem', lineHeight: 1 }}>
-      ×
-    </span>
-  </button>
-);
+}) => {
+  const xRef = useRef<HTMLSpanElement>(null);
+  return (
+    <button
+      type="button"
+      onClick={onRemove}
+      className="inline-flex items-center gap-1.5 font-mono font-medium uppercase transition"
+      style={{
+        color: INK_NAVY_SOFT,
+        fontSize: '0.64rem',
+        letterSpacing: '0.14em',
+        backgroundColor: CREAM_CHIP,
+        padding: '3px 10px',
+        border: `1px solid ${WALNUT_HAIRLINE}`,
+        borderRadius: 12,
+        boxShadow: 'inset 0 1px 0 rgba(255, 253, 244, 0.75), 0 1px 2px rgba(74, 52, 35, 0.08)',
+        whiteSpace: 'nowrap',
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.backgroundColor = CREAM_CHIP_HOT;
+        e.currentTarget.style.borderColor = OXBLOOD_SOFT;
+        if (xRef.current) xRef.current.style.color = OXBLOOD;
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.backgroundColor = CREAM_CHIP;
+        e.currentTarget.style.borderColor = WALNUT_HAIRLINE;
+        if (xRef.current) xRef.current.style.color = WALNUT_MUTED;
+      }}
+      title={title}
+    >
+      {label}
+      <span
+        ref={xRef}
+        aria-hidden="true"
+        style={{
+          color: WALNUT_MUTED,
+          fontSize: '0.78rem',
+          lineHeight: 1,
+          transition: 'color 200ms',
+        }}
+      >
+        ×
+      </span>
+    </button>
+  );
+};
 
 // ─── Main component ─────────────────────────────────────────────────────────
 const BookshelfControls: React.FC<BookshelfControlsProps> = ({
@@ -350,14 +378,13 @@ const BookshelfControls: React.FC<BookshelfControlsProps> = ({
                         onSortChange(opt.value);
                         close();
                       }}
-                      className="flex w-full items-center gap-2 px-3 py-1.5 font-mono text-[0.72rem] uppercase tracking-[0.14em] transition"
+                      className="flex w-full items-center gap-2 px-3.5 py-1.5 font-mono text-[0.7rem] uppercase tracking-[0.14em] transition"
                       style={{
-                        color: active ? INK : INK_DIM,
-                        backgroundColor: active ? 'rgba(58, 42, 30, 0.08)' : 'transparent',
+                        color: active ? INK_NAVY : WALNUT_MID,
+                        backgroundColor: active ? WALNUT_WHISPER : 'transparent',
                       }}
                       onMouseEnter={(e) => {
-                        if (!active)
-                          e.currentTarget.style.backgroundColor = 'rgba(58, 42, 30, 0.04)';
+                        if (!active) e.currentTarget.style.backgroundColor = WALNUT_BREATH;
                       }}
                       onMouseLeave={(e) => {
                         if (!active) e.currentTarget.style.backgroundColor = 'transparent';
@@ -365,7 +392,7 @@ const BookshelfControls: React.FC<BookshelfControlsProps> = ({
                     >
                       <span
                         aria-hidden="true"
-                        style={{ width: '0.7rem', color: INK, opacity: active ? 1 : 0 }}
+                        style={{ width: '0.7rem', color: OXBLOOD, opacity: active ? 1 : 0 }}
                       >
                         ◆
                       </span>
@@ -400,22 +427,19 @@ const BookshelfControls: React.FC<BookshelfControlsProps> = ({
                         role="menuitemcheckbox"
                         aria-checked={selected}
                         onClick={() => onToggleShelf(shelf.id)}
-                        className="flex w-full items-center gap-2 px-3 py-1.5 font-mono text-[0.72rem] uppercase tracking-[0.14em] transition"
+                        className="flex w-full items-center gap-2 px-3.5 py-1.5 font-mono text-[0.7rem] uppercase tracking-[0.14em] transition"
                         style={{
-                          color: selected ? INK : INK_DIM,
-                          backgroundColor: selected
-                            ? 'rgba(58, 42, 30, 0.08)'
-                            : 'transparent',
+                          color: selected ? INK_NAVY : WALNUT_MID,
+                          backgroundColor: selected ? WALNUT_WHISPER : 'transparent',
                         }}
                         onMouseEnter={(e) => {
-                          if (!selected)
-                            e.currentTarget.style.backgroundColor = 'rgba(58, 42, 30, 0.04)';
+                          if (!selected) e.currentTarget.style.backgroundColor = WALNUT_BREATH;
                         }}
                         onMouseLeave={(e) => {
                           if (!selected) e.currentTarget.style.backgroundColor = 'transparent';
                         }}
                       >
-                        <span aria-hidden="true" style={{ width: '0.7rem', color: INK }}>
+                        <span aria-hidden="true" style={{ width: '0.7rem', color: OXBLOOD }}>
                           {selected ? '◆' : ''}
                         </span>
                         {shelf.name}
@@ -450,7 +474,7 @@ const BookshelfControls: React.FC<BookshelfControlsProps> = ({
       <div
         className="hidden font-mono uppercase sm:block"
         style={{
-          color: INK_NAVY_DIM,
+          color: WALNUT_MUTED,
           fontSize: '0.58rem',
           letterSpacing: '0.24em',
           whiteSpace: 'nowrap',

--- a/frontend/src/components/bookshelf/BookshelfControls.tsx
+++ b/frontend/src/components/bookshelf/BookshelfControls.tsx
@@ -9,7 +9,6 @@ interface BookshelfControlsProps {
   allBookshelves: Bookshelf[];
   selectedShelfIds: number[];
   onToggleShelf: (id: number) => void;
-  onClearShelves: () => void;
   bookCount: number;
   searchQuery: string;
   onSearchChange: (val: string) => void;
@@ -319,7 +318,6 @@ const BookshelfControls: React.FC<BookshelfControlsProps> = ({
   allBookshelves,
   selectedShelfIds,
   onToggleShelf,
-  onClearShelves,
   bookCount,
   searchQuery,
   onSearchChange,
@@ -336,7 +334,6 @@ const BookshelfControls: React.FC<BookshelfControlsProps> = ({
       if (searchDraft !== searchQuery) onSearchChange(searchDraft);
     }, 250);
     return () => window.clearTimeout(t);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchDraft]);
 
   const sortLabel =

--- a/frontend/src/components/bookshelf/BookshelfControls.tsx
+++ b/frontend/src/components/bookshelf/BookshelfControls.tsx
@@ -390,31 +390,8 @@ const BookshelfControls: React.FC<BookshelfControlsProps> = ({
           onToggle={() => handleToggle('shelves')}
           popoverWidth={260}
           renderPopover={() => (
-            <div>
-              <div
-                className="flex items-center justify-between px-3 pt-2 pb-1 font-mono text-[0.6rem] uppercase tracking-[0.18em]"
-                style={{ color: INK_DIM }}
-              >
-                <span>Select shelves</span>
-                {selectedShelfIds.length > 0 && (
-                  <button
-                    type="button"
-                    onClick={onClearShelves}
-                    className="transition"
-                    style={{ color: INK_DIM }}
-                    onMouseEnter={(e) => (e.currentTarget.style.color = INK)}
-                    onMouseLeave={(e) => (e.currentTarget.style.color = INK_DIM)}
-                  >
-                    Clear
-                  </button>
-                )}
-              </div>
-              <ul
-                className="max-h-64 overflow-y-auto py-1"
-                role="menu"
-                style={{ borderTop: `1px solid ${INK_RULE}` }}
-              >
-                {allBookshelves.map((shelf) => {
+            <ul className="max-h-72 overflow-y-auto py-1.5" role="menu">
+              {allBookshelves.map((shelf) => {
                   const selected = selectedShelfIds.includes(shelf.id);
                   return (
                     <li key={shelf.id}>
@@ -447,7 +424,6 @@ const BookshelfControls: React.FC<BookshelfControlsProps> = ({
                   );
                 })}
               </ul>
-            </div>
           )}
         />
 

--- a/frontend/src/components/bookshelf/BookshelfControls.tsx
+++ b/frontend/src/components/bookshelf/BookshelfControls.tsx
@@ -86,37 +86,27 @@ const Popover: React.FC<{
   );
 };
 
-// ─── Sort anchor ("[sort-icon] Recent") ────────────────────────────────────
-interface SortAnchorProps {
+// ─── Text anchor — a clickable underlined value that opens a popover ───────
+interface TextAnchorProps {
   value: string;
   ariaLabel: string;
   open: boolean;
   onToggle: () => void;
+  popoverWidth?: number;
   renderPopover: (ctx: { close: () => void }) => React.ReactNode;
 }
 
-const SortAnchor: React.FC<SortAnchorProps> = ({
+const TextAnchor: React.FC<TextAnchorProps> = ({
   value,
   ariaLabel,
   open,
   onToggle,
+  popoverWidth = 240,
   renderPopover,
 }) => {
   const ref = useRef<HTMLButtonElement>(null);
   return (
-    <span className="relative inline-flex items-center gap-2">
-      <span
-        aria-hidden="true"
-        style={{
-          color: INK_NAVY_DIM,
-          display: 'inline-flex',
-          alignItems: 'center',
-          width: 18,
-          height: 18,
-        }}
-      >
-        <Icon name="sort" size="md" />
-      </span>
+    <span className="relative inline-flex items-center">
       <button
         ref={ref}
         type="button"
@@ -143,80 +133,120 @@ const SortAnchor: React.FC<SortAnchorProps> = ({
       >
         {value}
       </button>
-      <Popover open={open} onClose={onToggle} width={220} anchorRef={ref}>
+      <Popover open={open} onClose={onToggle} width={popoverWidth} anchorRef={ref}>
         {renderPopover({ close: onToggle })}
       </Popover>
     </span>
   );
 };
 
-// ─── Icon button (shelf, search) ───────────────────────────────────────────
-interface IconButtonProps {
-  icon: 'shelf' | 'search';
-  ariaLabel: string;
-  active: boolean;
-  open: boolean;
-  onToggle: () => void;
-  popoverWidth?: number;
-  popoverAlign?: 'left' | 'center' | 'right';
-  renderPopover: (ctx: { close: () => void }) => React.ReactNode;
+// ─── Inline search — icon expands to input on the same row, no popover ─────
+interface InlineSearchProps {
+  searchQuery: string;
+  searchDraft: string;
+  setSearchDraft: (val: string) => void;
+  onSearchChange: (val: string) => void;
 }
 
-const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
-  (
-    { icon, ariaLabel, active, open, onToggle, popoverWidth, popoverAlign, renderPopover },
-    ref,
-  ) => {
-    const localRef = useRef<HTMLButtonElement>(null);
-    React.useImperativeHandle(ref, () => localRef.current as HTMLButtonElement);
+const InlineSearch: React.FC<InlineSearchProps> = ({
+  searchQuery,
+  searchDraft,
+  setSearchDraft,
+  onSearchChange,
+}) => {
+  const [open, setOpen] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const searchActive = searchQuery.trim().length > 0;
+  const showInput = open || searchActive;
 
-    const color = active || open ? INK_NAVY : INK_NAVY_DIM;
+  const openSearch = () => {
+    setOpen(true);
+    // Focus the input once it renders
+    window.setTimeout(() => inputRef.current?.focus(), 0);
+  };
 
-    return (
-      <span className="relative inline-flex items-center">
-        <button
-          ref={localRef}
-          type="button"
-          onClick={onToggle}
-          aria-label={ariaLabel}
-          aria-haspopup="menu"
-          aria-expanded={open}
-          className="inline-flex items-center justify-center transition focus:outline-none"
-          style={{
-            color,
-            width: 24,
-            height: 24,
-            padding: 0,
-            backgroundColor: 'transparent',
-            borderBottom: `1px solid ${open ? INK_NAVY : 'transparent'}`,
-            paddingBottom: 2,
-            marginBottom: -3,
-          }}
-          onMouseEnter={(e) => {
-            if (!open && !active) e.currentTarget.style.color = INK_NAVY;
-          }}
-          onMouseLeave={(e) => {
-            if (!open && !active) e.currentTarget.style.color = INK_NAVY_DIM;
-          }}
-        >
-          <Icon name={icon} size="md" />
-        </button>
-        <Popover
-          open={open}
-          onClose={onToggle}
-          width={popoverWidth}
-          anchorRef={localRef}
-          align={popoverAlign}
-        >
-          {renderPopover({ close: onToggle })}
-        </Popover>
-      </span>
-    );
-  },
-);
-IconButton.displayName = 'IconButton';
+  const clearAndClose = () => {
+    setSearchDraft('');
+    onSearchChange('');
+    setOpen(false);
+  };
 
-// ─── Active-filter chip ─────────────────────────────────────────────────────
+  return (
+    <span className="relative inline-flex items-center gap-2">
+      <button
+        type="button"
+        onClick={openSearch}
+        aria-label={searchActive ? `Search: ${searchQuery}` : 'Search books'}
+        className="inline-flex items-center justify-center transition focus:outline-none"
+        style={{
+          color: showInput ? INK_NAVY : INK_NAVY_DIM,
+          width: 24,
+          height: 24,
+          padding: 0,
+          backgroundColor: 'transparent',
+        }}
+        onMouseEnter={(e) => {
+          if (!showInput) e.currentTarget.style.color = INK_NAVY;
+        }}
+        onMouseLeave={(e) => {
+          if (!showInput) e.currentTarget.style.color = INK_NAVY_DIM;
+        }}
+      >
+        <Icon name="search" size="md" />
+      </button>
+      {showInput && (
+        <>
+          <input
+            ref={inputRef}
+            type="text"
+            value={searchDraft}
+            onChange={(e) => setSearchDraft(e.target.value)}
+            onBlur={() => {
+              if (!searchDraft.trim()) setOpen(false);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') clearAndClose();
+              if (e.key === 'Enter') e.currentTarget.blur();
+            }}
+            placeholder="title, author"
+            className="bg-transparent font-mono uppercase outline-none placeholder:normal-case"
+            style={{
+              color: INK_NAVY,
+              fontSize: '0.7rem',
+              letterSpacing: '0.12em',
+              fontWeight: 600,
+              width: 160,
+              borderBottom: `1px solid ${INK_NAVY_QUIET}`,
+              paddingBottom: 2,
+            }}
+          />
+          {searchActive && (
+            <button
+              type="button"
+              onClick={clearAndClose}
+              aria-label="Clear search"
+              className="transition"
+              style={{
+                color: INK_NAVY_DIM,
+                fontSize: '0.9rem',
+                lineHeight: 1,
+                background: 'transparent',
+                padding: '0 2px',
+                marginLeft: -4,
+              }}
+              onMouseEnter={(e) => (e.currentTarget.style.color = INK_NAVY)}
+              onMouseLeave={(e) => (e.currentTarget.style.color = INK_NAVY_DIM)}
+            >
+              ×
+            </button>
+          )}
+        </>
+      )}
+    </span>
+  );
+};
+
+// ─── Active-filter chip (for selected shelves) ─────────────────────────────
 const FilterChip: React.FC<{ label: string; onRemove: () => void; title?: string }> = ({
   label,
   onRemove,
@@ -266,7 +296,7 @@ const BookshelfControls: React.FC<BookshelfControlsProps> = ({
   searchQuery,
   onSearchChange,
 }) => {
-  const [openSegment, setOpenSegment] = useState<null | 'sort' | 'shelves' | 'search'>(null);
+  const [openSegment, setOpenSegment] = useState<null | 'sort' | 'shelves'>(null);
   const [searchDraft, setSearchDraft] = useState(searchQuery);
 
   useEffect(() => {
@@ -284,21 +314,28 @@ const BookshelfControls: React.FC<BookshelfControlsProps> = ({
   const sortLabel =
     sortOptions.find((o) => o.value === selectedSortBy)?.label.toUpperCase() ?? '—';
 
-  const handleToggle = (which: 'sort' | 'shelves' | 'search') =>
+  const shelvesLabel =
+    selectedShelfIds.length === 0
+      ? 'ALL'
+      : selectedShelfIds.length === 1
+      ? (allBookshelves.find((s) => s.id === selectedShelfIds[0])?.name ?? '1').toUpperCase()
+      : `${selectedShelfIds.length} SELECTED`;
+
+  const handleToggle = (which: 'sort' | 'shelves') =>
     setOpenSegment((cur) => (cur === which ? null : which));
 
-  const searchActive = searchQuery.trim().length > 0;
   const selectedShelves = allBookshelves.filter((s) => selectedShelfIds.includes(s.id));
 
   return (
     <div className="relative flex flex-wrap items-center justify-between gap-x-6 gap-y-2">
-      <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
-        {/* [sort-icon] · Recent */}
-        <SortAnchor
+      <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
+        {/* Sort — clickable value ("RECENT") */}
+        <TextAnchor
           value={sortLabel}
           ariaLabel={`Sort by ${sortLabel.toLowerCase()}`}
           open={openSegment === 'sort'}
           onToggle={() => handleToggle('sort')}
+          popoverWidth={220}
           renderPopover={({ close }) => (
             <ul className="py-1.5" role="menu">
               {sortOptions.map((opt) => {
@@ -341,15 +378,14 @@ const BookshelfControls: React.FC<BookshelfControlsProps> = ({
           )}
         />
 
-        {/* Shelf icon button */}
-        <IconButton
-          icon="shelf"
+        {/* Shelf — clickable value ("ALL" by default) */}
+        <TextAnchor
+          value={shelvesLabel}
           ariaLabel={
             selectedShelves.length > 0
               ? `Filter by shelf (${selectedShelves.length} selected)`
               : 'Filter by shelf'
           }
-          active={selectedShelves.length > 0}
           open={openSegment === 'shelves'}
           onToggle={() => handleToggle('shelves')}
           popoverWidth={260}
@@ -415,74 +451,15 @@ const BookshelfControls: React.FC<BookshelfControlsProps> = ({
           )}
         />
 
-        {/* Search icon button */}
-        <IconButton
-          icon="search"
-          ariaLabel={searchActive ? `Search: ${searchQuery}` : 'Search books'}
-          active={searchActive}
-          open={openSegment === 'search'}
-          onToggle={() => handleToggle('search')}
-          popoverWidth={300}
-          renderPopover={({ close }) => (
-            <div className="px-3 py-2">
-              <label
-                className="mb-1 block font-mono text-[0.6rem] uppercase tracking-[0.18em]"
-                style={{ color: INK_DIM }}
-              >
-                Title or author
-              </label>
-              <input
-                autoFocus
-                type="text"
-                value={searchDraft}
-                onChange={(e) => setSearchDraft(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
-                    onSearchChange(searchDraft);
-                    close();
-                  }
-                }}
-                placeholder="e.g. Camus"
-                className="w-full bg-transparent font-mono text-[0.82rem] outline-none"
-                style={{
-                  color: INK,
-                  borderBottom: `1px solid ${INK_RULE}`,
-                  paddingBottom: 4,
-                }}
-              />
-              <div className="mt-2 flex items-center justify-between">
-                <button
-                  type="button"
-                  onClick={() => {
-                    setSearchDraft('');
-                    onSearchChange('');
-                  }}
-                  className="font-mono text-[0.6rem] uppercase tracking-[0.18em]"
-                  style={{ color: INK_DIM }}
-                >
-                  Clear
-                </button>
-                <button
-                  type="button"
-                  onClick={close}
-                  className="font-mono text-[0.6rem] uppercase tracking-[0.18em]"
-                  style={{ color: INK }}
-                >
-                  Done
-                </button>
-              </div>
-            </div>
-          )}
+        {/* Search — inline expand, no popover */}
+        <InlineSearch
+          searchQuery={searchQuery}
+          searchDraft={searchDraft}
+          setSearchDraft={setSearchDraft}
+          onSearchChange={onSearchChange}
         />
 
-        {/* Inline active-filter chips — sit on the same horizontal plane */}
-        {searchActive && (
-          <FilterChip
-            label={`"${searchQuery.trim()}"`}
-            onRemove={() => onSearchChange('')}
-            title="Clear search"
-          />
-        )}
+        {/* Active-shelf chips — sit on the same horizontal plane */}
         {selectedShelves.map((shelf) => (
           <FilterChip
             key={shelf.id}

--- a/frontend/src/components/bookshelf/BookshelfGrid.tsx
+++ b/frontend/src/components/bookshelf/BookshelfGrid.tsx
@@ -122,12 +122,16 @@ const BookshelfGrid: React.FC<BookshelfGridProps> = ({
                         '--current-hover-y': `${placement.hoverY}px`,
                         '--current-hover-r': `${placement.hoverRotate}deg`,
                         zIndex: currentBooks.length - placement.order + 20,
+                        // Currently-reading books get a warm walnut shadow plus a
+                        // faint oxblood glow — the book is being read, an ember
+                        // under the spine. The glow is small so it doesn't shout.
                         filter:
-                          'drop-shadow(0 4px 3px rgba(15, 29, 48, 0.20)) drop-shadow(0 1px 0 rgba(15, 29, 48, 0.30))',
+                          'drop-shadow(0 4px 3px rgba(74, 52, 35, 0.22)) drop-shadow(0 1px 0 rgba(74, 52, 35, 0.32)) drop-shadow(0 0 6px rgba(158, 58, 42, 0.18))',
                       } as React.CSSProperties)
                     : ({
+                        // Rested books get a plain warm walnut shadow — wood on paper.
                         filter:
-                          'drop-shadow(0 4px 3px rgba(15, 29, 48, 0.20)) drop-shadow(0 1px 0 rgba(15, 29, 48, 0.30))',
+                          'drop-shadow(0 4px 3px rgba(74, 52, 35, 0.22)) drop-shadow(0 1px 0 rgba(74, 52, 35, 0.32))',
                       } as React.CSSProperties)
                 }
               >

--- a/frontend/src/components/bookshelf/BookshelfGrid.tsx
+++ b/frontend/src/components/bookshelf/BookshelfGrid.tsx
@@ -8,7 +8,6 @@ interface BookshelfGridProps {
   bookSize: { width: number; height: number };
   currentBooks?: BookWithShelves[];
   controls?: React.ReactNode;
-  chips?: React.ReactNode;
 }
 
 // Chromeless shelves — the page IS the reading room. No frame, no case.
@@ -61,11 +60,8 @@ const BookshelfGrid: React.FC<BookshelfGridProps> = ({
   bookSize,
   currentBooks = [],
   controls,
-  chips,
 }) => {
-  if (books.length === 0) {
-    return <EmptyState message="No books found with the current filters" />;
-  }
+  const isEmpty = books.length === 0;
 
   const currentBookPlacements = new Map(
     currentBooks
@@ -75,20 +71,14 @@ const BookshelfGrid: React.FC<BookshelfGridProps> = ({
 
   return (
     <div className="relative">
-      {/* Filter line — sits on the page as typographic navigation, no chrome */}
-      {controls ? (
-        <div className="mb-5 px-1 sm:px-2">
-          {controls}
-        </div>
-      ) : null}
+      {/* Filter line — sits on the page as typographic navigation, no chrome.
+          Active-filter chips live inline on this same row (see BookshelfControls). */}
+      {controls ? <div className="mb-5 px-1 sm:px-2">{controls}</div> : null}
 
-      {/* Active-shelves chip rail */}
-      {chips ? (
-        <div className="mb-4 px-1 sm:px-2">
-          {chips}
-        </div>
-      ) : null}
-
+      {isEmpty ? (
+        <EmptyState message="No books found with the current filters" />
+      ) : (
+      <>
       {/* Shelves — a series of walnut planks with books resting on top.
           Overflow is visible so hover/rest transforms, drop shadows, and the
           splayed current-reading rotations don't get clipped at the edges. */}
@@ -147,6 +137,8 @@ const BookshelfGrid: React.FC<BookshelfGridProps> = ({
           })}
         </div>
       </div>
+      </>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/bookshelf/BookshelfGrid.tsx
+++ b/frontend/src/components/bookshelf/BookshelfGrid.tsx
@@ -1,92 +1,68 @@
 import React from 'react';
-import { BookWithShelves } from 'types/index'; // Changed Book to BookWithShelves
+import { BookWithShelves } from 'types/index';
 import { BookCard } from '../books';
 import { EmptyState } from '../ui';
 
 interface BookshelfGridProps {
-  books: BookWithShelves[]; // Changed Book[] to BookWithShelves[]
+  books: BookWithShelves[];
   bookSize: { width: number; height: number };
   currentBooks?: BookWithShelves[];
+  controls?: React.ReactNode;
+  chips?: React.ReactNode;
 }
 
-const getBookshelfFrameStyle = (bookSize: { width: number; height: number }) => {
-  const rowHeight = bookSize.height + 12;
-  const shelfColor = '#10203a';
+// Chromeless shelves — the page IS the reading room. No frame, no case.
+// Walnut planks float on the page's pale sky background; books sit on them.
+const WALNUT = '#4a3423';
+const WALNUT_EDGE = '#2a1d10';
+const SHELF_PLANK_HEIGHT = 14;
+const SHELF_GAP_BELOW = 14; // space between a plank and the next row of books above it
 
+const CURRENT_BOOK_TRANSFORMS = [
+  { restX: -4, restY: 4, restRotate: -8, hoverX: -12, hoverY: 11, hoverRotate: -14 },
+  { restX: 2, restY: -2, restRotate: 5, hoverX: 6, hoverY: -8, hoverRotate: 8 },
+  { restX: -2, restY: 3, restRotate: -4, hoverX: -8, hoverY: 7, hoverRotate: -7 },
+  { restX: 3, restY: -1, restRotate: 7, hoverX: 10, hoverY: -6, hoverRotate: 11 },
+  { restX: -3, restY: 2, restRotate: -6, hoverX: -9, hoverY: 6, hoverRotate: -9 },
+  { restX: 2, restY: -2, restRotate: 4, hoverX: 8, hoverY: -5, hoverRotate: 6 },
+];
+
+// Per-row: book sits on top of a walnut plank directly below it.
+// Below the plank is a hairline shadow, then breathing room before the next row.
+const getShelvesStyle = (bookSize: { width: number; height: number }) => {
+  const rowHeight = bookSize.height + SHELF_PLANK_HEIGHT + SHELF_GAP_BELOW;
+  const plankTop = bookSize.height;
+  const plankEdgeEnd = plankTop + 1;
+  const plankBottom = plankTop + SHELF_PLANK_HEIGHT - 2;
+  const shadowEnd = plankTop + SHELF_PLANK_HEIGHT;
   return {
     backgroundImage: `
-      radial-gradient(circle at 50% 0%, rgba(132, 181, 255, 0.16), transparent 28%),
-      linear-gradient(180deg, rgba(255,255,255,0.06), rgba(0,0,0,0.16)),
       repeating-linear-gradient(
         to bottom,
-        rgba(255,255,255,0.06) 0,
-        rgba(255,255,255,0.06) 2px,
-        rgba(8,15,27,0) 2px,
-        rgba(8,15,27,0) ${bookSize.height + 2}px,
-        rgba(132,181,255,0.2) ${bookSize.height + 2}px,
-        rgba(14,26,44,0.48) ${bookSize.height + 10}px,
-        ${shelfColor} ${rowHeight}px
-      ),
-      linear-gradient(135deg, #223652 0%, #17283f 38%, #0f1b2c 100%)
+        transparent 0,
+        transparent ${plankTop}px,
+        ${WALNUT_EDGE} ${plankTop}px,
+        ${WALNUT_EDGE} ${plankEdgeEnd}px,
+        ${WALNUT} ${plankEdgeEnd}px,
+        ${WALNUT} ${plankBottom}px,
+        rgba(0, 0, 0, 0.28) ${plankBottom}px,
+        rgba(0, 0, 0, 0.28) ${shadowEnd}px,
+        transparent ${shadowEnd}px,
+        transparent ${rowHeight}px
+      )
     `,
-    backgroundSize: `100% 100%, 100% 100%, 100% ${rowHeight}px, 100% 100%`,
+    backgroundSize: `100% ${rowHeight}px`,
     backgroundPosition: '0 0',
-    boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.08), inset 0 -14px 30px rgba(7,15,28,0.28)',
   };
 };
 
-const CURRENT_BOOK_TRANSFORMS = [
-  {
-    restX: -4,
-    restY: 4,
-    restRotate: -8,
-    hoverX: -12,
-    hoverY: 11,
-    hoverRotate: -14,
-  },
-  {
-    restX: 2,
-    restY: -2,
-    restRotate: 5,
-    hoverX: 6,
-    hoverY: -8,
-    hoverRotate: 8,
-  },
-  {
-    restX: -2,
-    restY: 3,
-    restRotate: -4,
-    hoverX: -8,
-    hoverY: 7,
-    hoverRotate: -7,
-  },
-  {
-    restX: 3,
-    restY: -1,
-    restRotate: 7,
-    hoverX: 10,
-    hoverY: -6,
-    hoverRotate: 11,
-  },
-  {
-    restX: -3,
-    restY: 2,
-    restRotate: -6,
-    hoverX: -9,
-    hoverY: 6,
-    hoverRotate: -9,
-  },
-  {
-    restX: 2,
-    restY: -2,
-    restRotate: 4,
-    hoverX: 8,
-    hoverY: -5,
-    hoverRotate: 6,
-  },
-];
-
-const BookshelfGrid: React.FC<BookshelfGridProps> = ({ books, bookSize, currentBooks = [] }) => {
+const BookshelfGrid: React.FC<BookshelfGridProps> = ({
+  books,
+  bookSize,
+  currentBooks = [],
+  controls,
+  chips,
+}) => {
   if (books.length === 0) {
     return <EmptyState message="No books found with the current filters" />;
   }
@@ -98,36 +74,46 @@ const BookshelfGrid: React.FC<BookshelfGridProps> = ({ books, bookSize, currentB
   );
 
   return (
-    <div
-      className="overflow-x-auto pb-4"
-      style={{
-        scrollbarWidth: 'thin',
-        scrollbarColor: '#6f8196 #edf2f7',
-      }}
-    >
+    <div className="relative">
+      {/* Filter line — sits on the page as typographic navigation, no chrome */}
+      {controls ? (
+        <div className="mb-5 px-1 sm:px-2">
+          {controls}
+        </div>
+      ) : null}
+
+      {/* Active-shelves chip rail */}
+      {chips ? (
+        <div className="mb-4 px-1 sm:px-2">
+          {chips}
+        </div>
+      ) : null}
+
+      {/* Shelves — a series of walnut planks with books resting on top.
+          Overflow is visible so hover/rest transforms, drop shadows, and the
+          splayed current-reading rotations don't get clipped at the edges. */}
       <div
-        className="site-frame relative overflow-hidden rounded-[34px] pt-6 p-4 sm:pt-7 sm:p-5"
-        style={getBookshelfFrameStyle(bookSize)}
+        className="relative"
+        style={{
+          ...getShelvesStyle(bookSize),
+        }}
       >
         <div
-          aria-hidden="true"
-          className="pointer-events-none absolute inset-x-0 top-0 h-14 bg-gradient-to-b from-white/[0.07] via-white/[0.02] to-transparent"
-        />
-        <div
-          aria-hidden="true"
-          className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(132,181,255,0.14),transparent_34%)]"
-        />
-
-        <div
-          className="relative z-10 grid gap-3"
+          className="relative grid"
           style={{
+            // Horizontal inset so first/last column books have room for
+            // negative translateX + rotation + drop-shadow without clipping
+            // against the container edge.
+            paddingLeft: 20,
+            paddingRight: 20,
+            paddingTop: 0,
             gridTemplateColumns: `repeat(auto-fill, minmax(${bookSize.width}px, 1fr))`,
+            gap: `${SHELF_PLANK_HEIGHT + SHELF_GAP_BELOW}px 12px`,
             perspective: '1000px',
           }}
         >
           {books.map((book) => {
             const placement = currentBookPlacements.get(book.id);
-
             return (
               <div
                 key={book.id}
@@ -146,8 +132,13 @@ const BookshelfGrid: React.FC<BookshelfGridProps> = ({ books, bookSize, currentB
                         '--current-hover-y': `${placement.hoverY}px`,
                         '--current-hover-r': `${placement.hoverRotate}deg`,
                         zIndex: currentBooks.length - placement.order + 20,
+                        filter:
+                          'drop-shadow(0 4px 3px rgba(15, 29, 48, 0.20)) drop-shadow(0 1px 0 rgba(15, 29, 48, 0.30))',
                       } as React.CSSProperties)
-                    : undefined
+                    : ({
+                        filter:
+                          'drop-shadow(0 4px 3px rgba(15, 29, 48, 0.20)) drop-shadow(0 1px 0 rgba(15, 29, 48, 0.30))',
+                      } as React.CSSProperties)
                 }
               >
                 <BookCard book={book} bookSize={bookSize} />

--- a/frontend/src/components/bookshelf/BookshelfQuoteDock/quoteDock.css
+++ b/frontend/src/components/bookshelf/BookshelfQuoteDock/quoteDock.css
@@ -40,32 +40,35 @@
   animation: driftInBookshelfDockVeil 1.38s cubic-bezier(0.19, 1, 0.22, 1) both;
 }
 
+/* Cream paper cloud — the quote reads off a lit page, not a cool sky. */
 .bookshelf-quote-dock__reading-cloud {
   background: radial-gradient(
     ellipse at center,
-    rgba(247, 250, 255, 0.82) 0%,
-    rgba(247, 250, 255, 0.64) 18%,
-    rgba(247, 250, 255, 0.28) 42%,
-    rgba(247, 250, 255, 0.08) 62%,
+    rgba(250, 245, 234, 0.88) 0%,
+    rgba(250, 245, 234, 0.70) 18%,
+    rgba(244, 236, 216, 0.32) 42%,
+    rgba(244, 236, 216, 0.10) 62%,
     transparent 100%
   );
 }
 
+/* Warm reading-lamp glow — amber/oxblood rather than cool sky-blue. */
 .bookshelf-quote-dock__reading-glow {
   background: radial-gradient(
     ellipse at center,
-    rgba(132, 181, 255, 0.18),
-    rgba(247, 250, 255, 0.08) 42%,
+    rgba(158, 58, 42, 0.10),
+    rgba(250, 245, 234, 0.10) 42%,
     transparent 76%
   );
   filter: blur(26px);
 }
 
+/* Walnut-ink mist — the faint warmth behind the paper. */
 .bookshelf-quote-dock__reading-mist {
   background: radial-gradient(
     ellipse at center,
-    rgba(233, 242, 255, 0.12) 0%,
-    rgba(233, 242, 255, 0.06) 22%,
+    rgba(74, 52, 35, 0.06) 0%,
+    rgba(74, 52, 35, 0.03) 22%,
     transparent 66%
   );
   filter: blur(44px);
@@ -73,8 +76,8 @@
 
 .bookshelf-quote-dock__preview {
   text-wrap: pretty;
-  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.52),
-    0 0 18px rgba(233, 242, 255, 0.32);
+  text-shadow: 0 1px 0 rgba(255, 253, 244, 0.58),
+    0 0 18px rgba(244, 236, 216, 0.34);
 }
 
 .bookshelf-quote-dock__inline-toggle {
@@ -84,7 +87,7 @@
   background: transparent;
   padding: 0;
   margin: 0;
-  color: rgba(48, 90, 154, 0.92);
+  color: rgba(74, 52, 35, 0.72);
   font-family: 'IBM Plex Mono', ui-monospace, monospace;
   font-size: 0.64rem;
   font-weight: 600;
@@ -98,7 +101,7 @@
 
 .bookshelf-quote-dock__inline-toggle:hover,
 .bookshelf-quote-dock__inline-toggle:focus-visible {
-  color: #2d63af;
+  color: #9e3a2a; /* oxblood */
   opacity: 1;
   outline: none;
 }
@@ -109,8 +112,8 @@
   justify-content: center;
   border: 0;
   background: transparent;
-  color: rgba(62, 84, 112, 0.22);
-  opacity: 0.18;
+  color: rgba(74, 52, 35, 0.32);
+  opacity: 0.22;
   transition: opacity 620ms cubic-bezier(0.19, 1, 0.22, 1),
     color 620ms cubic-bezier(0.19, 1, 0.22, 1),
     transform 620ms cubic-bezier(0.19, 1, 0.22, 1);
@@ -120,8 +123,8 @@
 .group\/bookshelf-dock:focus-within .bookshelf-quote-dock__edge-control,
 .bookshelf-quote-dock__edge-control:hover,
 .bookshelf-quote-dock__edge-control:focus-visible {
-  opacity: 0.72;
-  color: rgba(42, 73, 120, 0.84);
+  opacity: 0.78;
+  color: rgba(74, 52, 35, 0.86);
   transform: translateY(-50%) scale(1.02);
   outline: none;
 }
@@ -171,11 +174,11 @@
   width: 2.3rem;
   height: 0.24rem;
   border-radius: 999px;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.78), rgba(195, 209, 228, 0.96));
+  background: linear-gradient(180deg, rgba(255, 253, 244, 0.82), rgba(213, 199, 168, 0.92));
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.6),
-    0 5px 14px rgba(12, 23, 39, 0.12),
-    0 0 0 1px rgba(197, 211, 230, 0.36);
+    inset 0 1px 0 rgba(255, 253, 244, 0.65),
+    0 5px 14px rgba(74, 52, 35, 0.14),
+    0 0 0 1px rgba(213, 199, 168, 0.42);
   transition: width 420ms cubic-bezier(0.19, 1, 0.22, 1),
     background 420ms cubic-bezier(0.19, 1, 0.22, 1),
     box-shadow 420ms cubic-bezier(0.19, 1, 0.22, 1),
@@ -187,11 +190,11 @@
 .bookshelf-quote-dock__collapse-control:hover .bookshelf-quote-dock__collapse-bar,
 .bookshelf-quote-dock__collapse-control:focus-visible .bookshelf-quote-dock__collapse-bar {
   width: 2.55rem;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(175, 195, 220, 0.98));
+  background: linear-gradient(180deg, rgba(255, 253, 244, 0.94), rgba(191, 172, 135, 0.96));
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.72),
-    0 8px 18px rgba(12, 23, 39, 0.14),
-    0 0 0 1px rgba(165, 188, 216, 0.48);
+    inset 0 1px 0 rgba(255, 253, 244, 0.76),
+    0 8px 18px rgba(74, 52, 35, 0.16),
+    0 0 0 1px rgba(191, 172, 135, 0.54);
 }
 
 .bookshelf-quote-dock__markdown {
@@ -203,10 +206,10 @@
   font-size: 0.95rem;
   line-height: 1.62;
   margin-bottom: 0.75rem;
-  color: #223248;
+  color: #2a1f14; /* deep warm ink */
   text-align: center;
-  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.52),
-    0 0 18px rgba(233, 242, 255, 0.28);
+  text-shadow: 0 1px 0 rgba(255, 253, 244, 0.58),
+    0 0 18px rgba(244, 236, 216, 0.30);
 }
 
 .bookshelf-quote-dock__markdown p:last-child {
@@ -214,11 +217,11 @@
 }
 
 .bookshelf-quote-dock__markdown strong {
-  color: #15263f;
+  color: #15263f; /* navy ink for emphasis */
 }
 
 .bookshelf-quote-dock__markdown em {
-  color: #5f7286;
+  color: #6b4f35; /* walnut-mid for italic asides */
 }
 
 @media (min-width: 640px) {

--- a/frontend/src/components/common/Icon.tsx
+++ b/frontend/src/components/common/Icon.tsx
@@ -17,6 +17,7 @@ export type IconName =
   | 'quote-left'
   | 'search'
   | 'shelf'
+  | 'sort'
   | 'star'
   | 'star-empty'
   | 'trash'
@@ -173,10 +174,25 @@ const iconDefinitions: Record<IconName, IconDefinition> = {
     fill: 'none',
     stroke: 'currentColor',
     children: (
+      <g strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5">
+        {/* three book spines of varying height, standing on a shelf */}
+        <rect x="5" y="6" width="3" height="11" rx="0.5" />
+        <rect x="9.5" y="4" width="3" height="13" rx="0.5" />
+        <rect x="14" y="7" width="3" height="10" rx="0.5" />
+        <line x1="3" y1="19" x2="21" y2="19" />
+      </g>
+    ),
+  },
+  sort: {
+    viewBox: '0 0 24 24',
+    fill: 'none',
+    stroke: 'currentColor',
+    children: (
       <g strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.75">
+        {/* decreasing-width horizontal lines: classic A→Z sort glyph */}
         <line x1="4" y1="7" x2="20" y2="7" />
-        <line x1="4" y1="12" x2="20" y2="12" />
-        <line x1="4" y1="17" x2="20" y2="17" />
+        <line x1="4" y1="12" x2="15" y2="12" />
+        <line x1="4" y1="17" x2="10" y2="17" />
       </g>
     ),
   },

--- a/frontend/src/components/common/Icon.tsx
+++ b/frontend/src/components/common/Icon.tsx
@@ -16,6 +16,7 @@ export type IconName =
   | 'plus'
   | 'quote-left'
   | 'search'
+  | 'shelf'
   | 'star'
   | 'star-empty'
   | 'trash'
@@ -165,6 +166,18 @@ const iconDefinitions: Record<IconName, IconDefinition> = {
         strokeWidth="2"
         d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
       />
+    ),
+  },
+  shelf: {
+    viewBox: '0 0 24 24',
+    fill: 'none',
+    stroke: 'currentColor',
+    children: (
+      <g strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.75">
+        <line x1="4" y1="7" x2="20" y2="7" />
+        <line x1="4" y1="12" x2="20" y2="12" />
+        <line x1="4" y1="17" x2="20" y2="17" />
+      </g>
     ),
   },
   star: {

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -9,7 +9,7 @@ const DESKTOP_ICON_CLASSNAME = 'h-7 w-7';
 
 // Icon style constants
 const ICON_LINK_CLASSNAME =
-  'text-slate-100 hover:text-secondary-light no-underline transition duration-300';
+  'text-slate-100 hover:text-oxblood-light no-underline transition duration-300';
 const EMAIL_HREF = 'mailto:koryrkilpatrick@gmail.com';
 
 const NAV_LINKS = [
@@ -106,7 +106,7 @@ const Navbar: React.FC = () => {
           <div className="justify-self-start">
             <Link
               to="/"
-              className="flex items-center gap-3 text-white no-underline transition hover:text-secondary-light"
+              className="flex items-center gap-3 text-white no-underline transition hover:text-oxblood-light"
               aria-label="Homepage"
             >
               <span className="inline-flex h-14 w-14 items-center justify-center rounded-full border border-white/14 bg-white/[0.05] shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]">
@@ -128,7 +128,7 @@ const Navbar: React.FC = () => {
                 onFocus={link.path === '/bookshelf' ? handleBookshelfIntent : undefined}
                 className={`rounded-[12px] px-4 py-2 font-mono text-[0.74rem] uppercase tracking-[0.12em] no-underline transition ${
                   isActive(link.path)
-                    ? 'border border-secondary/40 bg-[rgba(63,127,216,0.26)] !text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.12)]'
+                    ? 'border border-oxblood/50 bg-[rgba(158,58,42,0.28)] !text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.12)]'
                     : '!text-slate-100 hover:bg-white/[0.12] hover:!text-white'
                 }`}
               >
@@ -143,7 +143,7 @@ const Navbar: React.FC = () => {
               href="https://www.5hc.ai/l/kory-kilpatrick/6930b6b6-baa7-419a-a441-eac0a7225a6e"
               target="_blank"
               rel="noopener noreferrer"
-              className="rounded-[12px] border border-white/20 bg-white/[0.08] px-3 py-1.5 font-mono text-[0.64rem] uppercase tracking-[0.1em] !text-slate-100 no-underline transition duration-300 hover:border-secondary/40 hover:bg-white/[0.12] hover:text-secondary-light"
+              className="rounded-[12px] border border-white/20 bg-white/[0.08] px-3 py-1.5 font-mono text-[0.64rem] uppercase tracking-[0.1em] !text-slate-100 no-underline transition duration-300 hover:border-oxblood/50 hover:bg-white/[0.12] hover:text-oxblood-light"
               aria-label="Five Hour Consulting profile"
             >
               5HC
@@ -201,7 +201,7 @@ const Navbar: React.FC = () => {
                   onTouchStart={link.path === '/bookshelf' ? handleBookshelfIntent : undefined}
                   className={`block rounded-[12px] px-3 py-2 font-mono text-[0.72rem] uppercase tracking-[0.12em] no-underline transition ${
                     isActive(link.path)
-                      ? 'border border-secondary/40 bg-[rgba(63,127,216,0.26)] !text-white'
+                      ? 'border border-oxblood/50 bg-[rgba(158,58,42,0.28)] !text-white'
                       : '!text-slate-100 hover:bg-white/[0.12] hover:!text-white'
                   }`}
                   onClick={() => setIsMenuOpen(false)}
@@ -215,7 +215,7 @@ const Navbar: React.FC = () => {
                   href="https://www.5hc.ai/l/kory-kilpatrick/6930b6b6-baa7-419a-a441-eac0a7225a6e"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="rounded-[12px] border border-white/20 bg-white/[0.08] px-3 py-1.5 font-mono text-[0.62rem] uppercase tracking-[0.1em] !text-slate-100 no-underline transition duration-300 hover:border-secondary/40 hover:bg-white/[0.12] hover:text-secondary-light"
+                  className="rounded-[12px] border border-white/20 bg-white/[0.08] px-3 py-1.5 font-mono text-[0.62rem] uppercase tracking-[0.1em] !text-slate-100 no-underline transition duration-300 hover:border-oxblood/50 hover:bg-white/[0.12] hover:text-oxblood-light"
                   aria-label="Five Hour Consulting profile"
                 >
                   5HC

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -15,18 +15,30 @@ const AboutPage: React.FC = () => {
           <button
             type="button"
             onClick={() => setIsModalOpen(true)}
-            className="group block w-full text-left transition hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary/25"
+            className="group block w-full text-left transition hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-oxblood/30"
             aria-label={`View larger image: ${altText}`}
           >
+            {/* Cream-paper frame around the photo — like a mounted print on a library wall.
+                Walnut hairline border + warm shadow sits the photo on the page rather than
+                floating it in a cool-glass vignette. */}
             <img
               src={imageUrl}
               alt={altText}
-              className="aspect-[4/5] w-full rounded-[28px] border border-white/70 object-cover shadow-[0_24px_52px_rgba(15,28,46,0.16)] transition duration-700 group-hover:scale-[1.01]"
+              className="aspect-[4/5] w-full rounded-[28px] border border-[rgba(74,52,35,0.22)] object-cover shadow-[0_24px_52px_rgba(74,52,35,0.18)] transition duration-700 group-hover:scale-[1.01]"
             />
           </button>
         </div>
 
         <div className="max-w-[36rem]">
+          {/* Signature eyebrow — the house mark ◆ between walnut hairlines.
+              Same mark appears under the navbar wordmark and as the selection
+              marker in the bookshelf's filter popover. The repetition is the point;
+              it says "this site has a hand" without having to announce it in words. */}
+          <div aria-hidden="true" className="mb-7 flex items-center gap-3">
+            <span className="h-px flex-1 bg-[rgba(74,52,35,0.22)]" />
+            <span className="text-[0.65rem] leading-none text-oxblood/85">◆</span>
+            <span className="h-px flex-1 bg-[rgba(74,52,35,0.22)]" />
+          </div>
           <div className="space-y-5 text-[1.04rem] leading-[1.88] sm:text-[1.1rem] sm:leading-[1.92]">
             <p className="text-textPrimary">
               I like solving problems, helping people, and cleaning the lens
@@ -36,7 +48,7 @@ const AboutPage: React.FC = () => {
                 href="https://waitbutwhy.com/2015/01/artificial-intelligence-revolution-1.html"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-secondary underline decoration-secondary/30 underline-offset-2 transition hover:decoration-secondary/60"
+                className="text-primary underline decoration-walnut/40 underline-offset-2 transition hover:text-oxblood hover:decoration-oxblood/60"
               >
                 this article
               </a>{' '}

--- a/frontend/src/pages/BookshelfPage.tsx
+++ b/frontend/src/pages/BookshelfPage.tsx
@@ -1,7 +1,9 @@
 import React, { useMemo, useState } from 'react';
 import { Loading, ErrorDisplay } from '../components/ui';
 import { Bookshelf, BookWithShelves, SortOption } from 'types/index';
-import BookshelfControls from '../components/bookshelf/BookshelfControls';
+import BookshelfControls, {
+  BookshelfSelectionChips,
+} from '../components/bookshelf/BookshelfControls';
 import BookshelfGrid from '../components/bookshelf/BookshelfGrid';
 import BookshelfQuoteDock from '../components/bookshelf/BookshelfQuoteDock';
 import useMultiSelect from '../hooks/useMultiSelect';
@@ -107,22 +109,32 @@ const BookshelfPageContent: React.FC = () => {
           'calc(var(--bookshelf-quote-dock-height, 7.5rem) + 1.5rem + env(safe-area-inset-bottom))',
       }}
     >
-      <BookshelfControls
-        sortOptions={sortOptions}
-        selectedSortBy={sortBy}
-        onSortChange={setSortBy}
-        allBookshelves={bookshelves}
-        selectedShelfIds={selectedShelves}
-        onToggleShelf={toggleShelfSelection}
-        onClearShelves={clearSelection}
-        bookCount={filteredAndSortedBooks.length}
-        searchQuery={searchQuery}
-        onSearchChange={setSearchQuery}
-      />
       <BookshelfGrid
         books={filteredAndSortedBooks}
         currentBooks={currentBooks}
         bookSize={SHELF_BOOK_SIZE}
+        controls={
+          <BookshelfControls
+            sortOptions={sortOptions}
+            selectedSortBy={sortBy}
+            onSortChange={setSortBy}
+            allBookshelves={bookshelves}
+            selectedShelfIds={selectedShelves}
+            onToggleShelf={toggleShelfSelection}
+            onClearShelves={clearSelection}
+            bookCount={filteredAndSortedBooks.length}
+            searchQuery={searchQuery}
+            onSearchChange={setSearchQuery}
+          />
+        }
+        chips={
+          <BookshelfSelectionChips
+            allBookshelves={bookshelves}
+            selectedShelfIds={selectedShelves}
+            onToggleShelf={toggleShelfSelection}
+            onClearShelves={clearSelection}
+          />
+        }
       />
       <BookshelfQuoteDock />
     </div>

--- a/frontend/src/pages/BookshelfPage.tsx
+++ b/frontend/src/pages/BookshelfPage.tsx
@@ -1,9 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { Loading, ErrorDisplay } from '../components/ui';
 import { Bookshelf, BookWithShelves, SortOption } from 'types/index';
-import BookshelfControls, {
-  BookshelfSelectionChips,
-} from '../components/bookshelf/BookshelfControls';
+import BookshelfControls from '../components/bookshelf/BookshelfControls';
 import BookshelfGrid from '../components/bookshelf/BookshelfGrid';
 import BookshelfQuoteDock from '../components/bookshelf/BookshelfQuoteDock';
 import useMultiSelect from '../hooks/useMultiSelect';
@@ -14,7 +12,7 @@ import {
 } from '../components/bookshelf/bookshelfReadingState';
 
 const sortOptions: SortOption[] = [
-  { label: 'Recently Read', value: 'date_read' },
+  { label: 'Recent', value: 'date_read' },
   { label: 'Title', value: 'title' },
   { label: 'Author', value: 'author' },
   { label: 'Published Date', value: 'date_pub' },
@@ -125,14 +123,6 @@ const BookshelfPageContent: React.FC = () => {
             bookCount={filteredAndSortedBooks.length}
             searchQuery={searchQuery}
             onSearchChange={setSearchQuery}
-          />
-        }
-        chips={
-          <BookshelfSelectionChips
-            allBookshelves={bookshelves}
-            selectedShelfIds={selectedShelves}
-            onToggleShelf={toggleShelfSelection}
-            onClearShelves={clearSelection}
           />
         }
       />

--- a/frontend/src/pages/BookshelfPage.tsx
+++ b/frontend/src/pages/BookshelfPage.tsx
@@ -27,7 +27,6 @@ const BookshelfPageContent: React.FC = () => {
   const {
     selectedItems: selectedShelves,
     toggleSelection: toggleShelfSelection,
-    clearSelection,
   } = useMultiSelect<number>([]);
 
   const [sortBy, setSortBy] = useState<string>('date_read');
@@ -119,7 +118,6 @@ const BookshelfPageContent: React.FC = () => {
             allBookshelves={bookshelves}
             selectedShelfIds={selectedShelves}
             onToggleShelf={toggleShelfSelection}
-            onClearShelves={clearSelection}
             bookCount={filteredAndSortedBooks.length}
             searchQuery={searchQuery}
             onSearchChange={setSearchQuery}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -16,16 +16,20 @@
 
   body {
     @apply min-h-screen bg-background font-sans text-[15px] leading-[1.68] text-textPrimary antialiased md:text-base;
+    /* Warm cream paper ground.
+       Walnut radial at the top gives the page a gentle "aged at the top" gradient
+       without announcing itself; oxblood radial at the upper right is the whisper
+       of the stamp accent threaded through the page. */
     background-image:
-      radial-gradient(circle at top, rgba(63, 127, 216, 0.18), transparent 28%),
-      radial-gradient(circle at 16% 10%, rgba(21, 38, 63, 0.12), transparent 30%),
-      radial-gradient(circle at 82% 10%, rgba(74, 128, 208, 0.08), transparent 24%),
-      linear-gradient(180deg, #f6f9fc 0%, #eff4f9 34%, #eaf0f7 70%, #e6edf5 100%);
+      radial-gradient(circle at 50% -10%, rgba(74, 52, 35, 0.06), transparent 32%),
+      radial-gradient(circle at 85% 8%, rgba(158, 58, 42, 0.04), transparent 28%),
+      radial-gradient(circle at 10% 95%, rgba(74, 52, 35, 0.05), transparent 26%),
+      linear-gradient(180deg, #faf3df 0%, #f4ecd8 38%, #efe5c9 74%, #ebe0be 100%);
     background-attachment: fixed;
   }
 
   body::selection {
-    background: rgba(63, 127, 216, 0.18);
+    background: rgba(158, 58, 42, 0.18);
     color: #15263f;
   }
 
@@ -55,7 +59,11 @@
   }
 
   a {
-    @apply text-primary underline-offset-4 transition duration-300 hover:text-secondary-dark;
+    @apply text-primary underline-offset-4 transition duration-300 hover:text-oxblood;
+    text-decoration-color: rgba(74, 52, 35, 0.35);
+  }
+  a:hover {
+    text-decoration-color: rgba(158, 58, 42, 0.65);
   }
 
   button,
@@ -79,20 +87,24 @@
     @apply rounded-md my-4;
   }
 
+  /* Cards are cream-paper with walnut hairlines and warm shadows —
+     a book laid on a desk, not a glassy SaaS card. */
   .site-card {
-    @apply rounded-[24px] border border-[rgba(21,38,63,0.09)] bg-[linear-gradient(180deg,rgba(255,255,255,0.92),rgba(244,248,252,0.82))] shadow-[0_18px_44px_rgba(21,38,63,0.09)] backdrop-blur-[4px];
+    @apply rounded-[24px] border border-[rgba(74,52,35,0.14)] bg-[linear-gradient(180deg,rgba(250,245,234,0.94),rgba(244,236,216,0.88))] shadow-[0_18px_44px_rgba(74,52,35,0.10)] backdrop-blur-[4px];
   }
 
   .site-card-soft {
-    @apply rounded-[20px] border border-[rgba(255,255,255,0.68)] bg-[linear-gradient(180deg,rgba(255,255,255,0.74),rgba(240,245,250,0.56))] shadow-[0_12px_30px_rgba(21,38,63,0.06)] backdrop-blur-[8px];
+    @apply rounded-[20px] border border-[rgba(74,52,35,0.12)] bg-[linear-gradient(180deg,rgba(250,245,234,0.82),rgba(244,236,216,0.68))] shadow-[0_12px_30px_rgba(74,52,35,0.08)] backdrop-blur-[8px];
   }
 
+  /* Dark cloth binding — navy-glass frame for pull-quote cards / hover panels.
+     Reads as a navy-bound book on cream paper. */
   .site-frame {
-    @apply rounded-[28px] border border-[rgba(104,131,166,0.22)] bg-[linear-gradient(180deg,rgba(25,41,64,0.98),rgba(13,24,39,0.99))] shadow-[0_24px_72px_rgba(15,28,46,0.22)];
+    @apply rounded-[28px] border border-[rgba(137,181,255,0.18)] bg-[linear-gradient(180deg,rgba(25,41,64,0.98),rgba(13,24,39,0.99))] shadow-[0_24px_72px_rgba(15,28,46,0.22)];
   }
 
   .site-eyebrow {
-    @apply font-mono text-[0.7rem] font-medium uppercase tracking-[0.22em] text-secondary-dark;
+    @apply font-mono text-[0.7rem] font-medium uppercase tracking-[0.22em] text-oxblood;
   }
 
   .site-meta {
@@ -100,14 +112,14 @@
   }
 
   .site-field {
-    @apply rounded-[14px] border border-[rgba(21,38,63,0.12)] bg-[rgba(255,255,255,0.76)] shadow-[inset_0_1px_0_rgba(255,255,255,0.7)] backdrop-blur-[4px];
+    @apply rounded-[14px] border border-[rgba(74,52,35,0.16)] bg-[rgba(250,245,234,0.78)] shadow-[inset_0_1px_0_rgba(255,253,244,0.8)] backdrop-blur-[4px];
   }
 
   .site-divider {
-    @apply h-px bg-gradient-to-r from-transparent via-[rgba(21,38,63,0.12)] to-transparent;
+    @apply h-px bg-gradient-to-r from-transparent via-[rgba(74,52,35,0.18)] to-transparent;
   }
 
   .site-link-chip {
-    @apply inline-flex items-center rounded-[12px] border border-[rgba(21,38,63,0.12)] bg-white/60 px-3 py-1.5 font-mono text-[0.68rem] font-medium uppercase tracking-[0.12em] text-textSecondary no-underline transition duration-300 hover:border-secondary/30 hover:bg-white/80 hover:text-primary;
+    @apply inline-flex items-center rounded-[12px] border border-[rgba(74,52,35,0.18)] bg-[rgba(250,245,234,0.68)] px-3 py-1.5 font-mono text-[0.68rem] font-medium uppercase tracking-[0.12em] text-textSecondary no-underline transition duration-300 hover:border-oxblood/40 hover:bg-[rgba(250,245,234,0.92)] hover:text-oxblood;
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,20 +13,45 @@ module.exports = {
   theme: {
     extend: {
       colors: {
+        // Primary ink — navy, used for body text, navbar, anchors, primary chrome
         primary: {
           DEFAULT: '#15263f',
           dark: '#0c1727',
           light: '#274361',
         },
+        // Kept for specific legacy uses (e.g. navbar social-link icon hover),
+        // but the house palette now routes interactive accents through `oxblood`.
         secondary: {
           DEFAULT: '#3f7fd8',
           dark: '#2d63af',
           light: '#84b5ff',
         },
-        textPrimary: '#172331',
-        textSecondary: '#4a5a6c',
-        textTertiary: '#7d8b99',
-        background: '#edf2f8',
+        // Paper — the site's warm ground. Cream-stock, not cool sky.
+        cream: {
+          DEFAULT: '#f4ecd8', // main page paper
+          light: '#faf5ea',   // almost-white, warm
+          deep: '#ebe0c6',    // slightly deeper paper (popover surface)
+          deeper: '#e1d4b3',  // card edges, rules
+        },
+        // Warm neutral — walnut, the library's wood. Shelves already use this.
+        // Promoted from shelf-only to systematic warm ink (dividers, meta, chip borders).
+        walnut: {
+          DEFAULT: '#4a3423',
+          dark: '#2a1d10',
+          mid: '#6b4f35',
+          light: '#8b6f4f',
+        },
+        // Stamp accent — oxblood. Used sparingly (≤10%) for punctuation:
+        // reading-now dot, active tab, the house dingbat, link hover.
+        oxblood: {
+          DEFAULT: '#9e3a2a',
+          light: '#b54a37',
+          dark: '#7a2b1e',
+        },
+        textPrimary: '#172331',  // navy ink on cream — unchanged, reads classic
+        textSecondary: '#4a3d2a', // warm charcoal (walnut-ink) replacing cool slate
+        textTertiary: '#7b6a50',  // warm muted — walnut.light territory
+        background: '#f4ecd8',    // cream (was cool sky #edf2f8)
         stone: {
           50: '#f7f9fb',
           100: '#edf2f7',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -69,7 +69,7 @@ module.exports = (_env, argv) => {
     },
     devServer: {
       historyApiFallback: true,
-      port: 3000,
+      port: process.env.PORT ? Number(process.env.PORT) : 3000,
       hot: true,
       proxy: {
         '/api': {


### PR DESCRIPTION
## Summary

Large-scope visual overhaul of the site. Two major threads landed together on this branch:

1. **Warm library palette** — site-wide shift from a cool blue/white register to the four-note library chord defined in `docs/DESIGN.md`:
   - **Paper** (cream `#f4ecd8` / `#faf5ea`) — ground, body surfaces
   - **Ink** (navy `#15263f`) — primary text, anchors, navbar frame
   - **Wood** (walnut `#4a3423` / `#6b4f35`) — dividers, rules, chip borders, shelf planks, warm shadows
   - **Stamp** (oxblood `#9e3a2a`) — ≤10% usage: active pill, dingbat, ember glow, link hover

2. **Chromeless shelves** — the bookshelf page loses its framed "case" in favor of walnut planks floating on cream paper. Filter row compressed to text anchors + inline search. Currently-reading books get a splayed rest/hover transform and an oxblood ember glow.

## Pattern vocabulary added to DESIGN.md
- Paper-slip popover (filter dropdown — cream paper over backdrop-blur, walnut hairline)
- Paper-slip chip (removable selections — reads as an index slip inline with typography)
- House dingbat (◆) — shared mark between About eyebrow, popover selection marker, and currently-reading ember
- Warm navbar pill (navy-glass with oxblood-tinted active pill)
- Navy-cloth tooltip (book-hover panels matching the navbar material)

## Files touched
- `tailwind.config.js` — cream/walnut/oxblood color families; warm-charcoal `textSecondary`
- `frontend/src/styles/global.css` — warm cream ground with walnut/oxblood radial whispers; site-card-soft, site-link-chip, site-eyebrow, site-meta, site-field, site-divider tokens rebuilt
- `frontend/src/components/bookshelf/BookshelfControls.tsx` — paper-slip popover + paper-slip chip patterns; palette tokens
- `frontend/src/components/bookshelf/BookshelfGrid.tsx` — chromeless shelves; walnut drop-shadow + oxblood ember for current-reading
- `frontend/src/components/bookshelf/BookshelfQuoteDock/quoteDock.css` — warmed from cool-sky to cream/walnut; oxblood reading-glow
- `frontend/src/components/books/BookCard.tsx` — tooltip to navy-cloth; hover glow to oxblood
- `frontend/src/components/layout/Navbar.tsx` — active pill to oxblood tint; hovers to oxblood
- `frontend/src/pages/AboutPage.tsx` — walnut-hairline photo frame + signature eyebrow (walnut rule · ◆ · walnut rule)
- `docs/DESIGN.md` — palette + pattern-vocabulary documentation

## Minor cleanups included
- Dead `onClearShelves` prop removed from `BookshelfControls` and `BookshelfPage` (declared and forwarded but never invoked)
- Stale `// eslint-disable-next-line react-hooks/exhaustive-deps` removed (plugin not configured; referenced an undefined rule)
- `webpack.config.js` dev-server port now respects `PORT` env var (minor dev ergonomics)

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run build` passes (size warnings are pre-existing)
- [x] Frontend test suite (49 tests) passes
- [ ] Post-deploy: visual confirmation on live site — palette reads warm across About and Bookshelf
- [ ] Post-deploy: currently-reading ember glow is visible at reasonable viewing distance
- [ ] Post-deploy: filter popover + chips read as paper-slip on cream ground

Note: the `Server` CI job is pre-existing failing on `main` (OpenAI API key mocking in `libraryExtraction.controller.test.ts`) — unrelated to any change on this branch. The `Frontend` CI job is the one that validates this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
